### PR TITLE
feat: 一覧表を統合テーブルに変更

### DIFF
--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -70,15 +70,15 @@ export function DepartureBoard({
 	}, [groups]);
 
 	// 行先の選択肢
-	const destinations = useMemo(() => {
-		const seen = new Map<string, string>();
-		for (const group of groups) {
-			if (!seen.has(group.toStopId)) {
-				seen.set(group.toStopId, group.toStopName);
-			}
-		}
-		return seen;
-	}, [groups]);
+	const destinations = useMemo(
+		() =>
+			new Map(
+				groups.map(
+					(group) => [group.toStopId, group.toStopName] as const,
+				),
+			),
+		[groups],
+	);
 
 	// groups 更新後に選択中の行先が消えた場合は "all" にフォールバック
 	const effectiveSelectedDestination =

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -80,11 +80,19 @@ export function DepartureBoard({
 		return seen;
 	}, [groups]);
 
+	// groups 更新後に選択中の行先が消えた場合は "all" にフォールバック
+	const effectiveSelectedDestination =
+		selectedDestination === "all" || destinations.has(selectedDestination)
+			? selectedDestination
+			: "all";
+
 	// フィルタ適用
 	const filteredDepartures = useMemo(() => {
-		if (selectedDestination === "all") return allDepartures;
-		return allDepartures.filter((dep) => dep.toStopId === selectedDestination);
-	}, [allDepartures, selectedDestination]);
+		if (effectiveSelectedDestination === "all") return allDepartures;
+		return allDepartures.filter(
+			(dep) => dep.toStopId === effectiveSelectedDestination,
+		);
+	}, [allDepartures, effectiveSelectedDestination]);
 
 	if (!hasRoutes) {
 		return (
@@ -146,8 +154,9 @@ export function DepartureBoard({
 							)}
 							{destinations.size > 1 && (
 								<select
+									aria-label="行き先で絞り込む"
 									className="select select-sm select-bordered"
-									value={selectedDestination}
+									value={effectiveSelectedDestination}
 									onChange={(e) => setSelectedDestination(e.target.value)}
 								>
 									<option value="all">全ての行先</option>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import type { DepartureGroup } from "../hooks/useDepartures";
 import { getAgencyColor } from "../lib/agency-colors";
-import type { Departure } from "../lib/departure-query";
 
 type DepartureBoardProps = {
 	/** 降車バス停ごとの発車案内グループ */
@@ -59,19 +58,15 @@ export function DepartureBoard({
 
 	// 全グループの便を統合し、発車時刻順にソート
 	const allDepartures = useMemo(() => {
-		const deps: (Departure & { toStopName: string; isNextDay?: boolean })[] =
-			[];
-		for (const group of groups) {
-			for (const dep of group.departures) {
-				deps.push({
+		return groups
+			.flatMap((group) =>
+				group.departures.map((dep) => ({
 					...dep,
 					toStopName: group.toStopName,
 					isNextDay: group.isNextDay,
-				});
-			}
-		}
-		deps.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
-		return deps;
+				})),
+			)
+			.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
 	}, [groups]);
 
 	// 行先の選択肢

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -42,8 +42,8 @@ function formatUpdatedTime(date: Date): string {
 	return updatedTimeFormatter.format(date);
 }
 
-/** 表示する行数の上限 */
-const VISIBLE_ROWS = 5;
+/** スクロール領域の最大高さ（Tailwind の max-h-60 = 15rem 相当） */
+const SCROLL_MAX_HEIGHT_CLASS = "max-h-60";
 
 /** 発車案内を降車バス停ごとにグルーピングして表示するコンポーネント */
 export function DepartureBoard({
@@ -112,10 +112,6 @@ export function DepartureBoard({
 
 	const allNextDay = groups.length > 0 && groups.every((g) => g.isNextDay);
 
-	// テーブル1行あたりの推定高さ（px）
-	const rowHeight = 40;
-	const maxHeight = rowHeight * VISIBLE_ROWS;
-
 	return (
 		<div className="space-y-4">
 			{lastUpdated && (
@@ -163,9 +159,11 @@ export function DepartureBoard({
 								</select>
 							)}
 						</div>
-						<div className="overflow-x-auto">
+						<div
+							className={`overflow-x-auto overflow-y-auto ${SCROLL_MAX_HEIGHT_CLASS}`}
+						>
 							<table className="table table-sm">
-								<thead>
+								<thead className="sticky top-0 z-10 bg-base-100">
 									<tr>
 										<th>出発目安</th>
 										<th>乗車</th>
@@ -176,70 +174,63 @@ export function DepartureBoard({
 										<th>行き先</th>
 									</tr>
 								</thead>
-							</table>
-							<div
-								className="overflow-y-auto"
-								style={{ maxHeight: `${maxHeight}px` }}
-							>
-								<table className="table table-sm">
-									<tbody>
-										{filteredDepartures.map((dep) => {
-											const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
-											const isHovered = hoveredRouteKey === routeKey;
-											const agencyColor = getAgencyColor(dep.routeId);
-											return (
-												<tr
-													key={`${dep.tripId}-${dep.departureTime}`}
-													className={`${isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""}`}
-													tabIndex={0}
-													onMouseEnter={() => onRouteHover?.(routeKey)}
-													onMouseLeave={() => onRouteHover?.(null)}
-													onFocus={() => onRouteHover?.(routeKey)}
-													onBlur={() => onRouteHover?.(null)}
-												>
-													<td className="font-mono">
-														{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
-														{dep.isDeparted && (
-															<span className="ml-1 badge badge-sm badge-ghost">
-																出発済
-															</span>
-														)}
-													</td>
-													<td>{dep.fromStopName ?? "-"}</td>
-													<td className="font-mono">
-														{formatTime(dep.departureTime)}
-													</td>
-													<td className="font-mono">
-														{formatTime(dep.arrivalTime)}
-													</td>
-													<td>
-														{dep.fare
-															? formatFare(dep.fare.price, dep.fare.currencyType)
-															: "-"}
-													</td>
-													<td>
-														<span className="inline-flex items-center gap-1">
-															{agencyColor && (
-																<span
-																	className="inline-block w-3 h-3 rounded-full flex-shrink-0"
-																	style={{
-																		backgroundColor: agencyColor.color,
-																	}}
-																	title={agencyColor.agencyName}
-																	aria-label={agencyColor.agencyName}
-																	role="img"
-																/>
-															)}
-															{dep.routeName}
+								<tbody>
+									{filteredDepartures.map((dep) => {
+										const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
+										const isHovered = hoveredRouteKey === routeKey;
+										const agencyColor = getAgencyColor(dep.routeId);
+										return (
+											<tr
+												key={`${dep.tripId}-${dep.departureTime}`}
+												className={`${isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""}`}
+												tabIndex={0}
+												onMouseEnter={() => onRouteHover?.(routeKey)}
+												onMouseLeave={() => onRouteHover?.(null)}
+												onFocus={() => onRouteHover?.(routeKey)}
+												onBlur={() => onRouteHover?.(null)}
+											>
+												<td className="font-mono">
+													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
+													{dep.isDeparted && (
+														<span className="ml-1 badge badge-sm badge-ghost">
+															出発済
 														</span>
-													</td>
-													<td>{dep.headsign}</td>
-												</tr>
-											);
-										})}
-									</tbody>
-								</table>
-							</div>
+													)}
+												</td>
+												<td>{dep.fromStopName ?? "-"}</td>
+												<td className="font-mono">
+													{formatTime(dep.departureTime)}
+												</td>
+												<td className="font-mono">
+													{formatTime(dep.arrivalTime)}
+												</td>
+												<td>
+													{dep.fare
+														? formatFare(dep.fare.price, dep.fare.currencyType)
+														: "-"}
+												</td>
+												<td>
+													<span className="inline-flex items-center gap-1">
+														{agencyColor && (
+															<span
+																className="inline-block w-3 h-3 rounded-full flex-shrink-0"
+																style={{
+																	backgroundColor: agencyColor.color,
+																}}
+																title={agencyColor.agencyName}
+																aria-label={agencyColor.agencyName}
+																role="img"
+															/>
+														)}
+														{dep.routeName}
+													</span>
+												</td>
+												<td>{dep.headsign}</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</table>
 						</div>
 					</div>
 				</div>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -1,5 +1,7 @@
+import { useMemo, useState } from "react";
 import type { DepartureGroup } from "../hooks/useDepartures";
 import { getAgencyColor } from "../lib/agency-colors";
+import type { Departure } from "../lib/departure-query";
 
 type DepartureBoardProps = {
 	/** 降車バス停ごとの発車案内グループ */
@@ -41,6 +43,9 @@ function formatUpdatedTime(date: Date): string {
 	return updatedTimeFormatter.format(date);
 }
 
+/** 表示する行数の上限 */
+const VISIBLE_ROWS = 5;
+
 /** 発車案内を降車バス停ごとにグルーピングして表示するコンポーネント */
 export function DepartureBoard({
 	groups,
@@ -50,6 +55,42 @@ export function DepartureBoard({
 	hoveredRouteKey,
 	onRouteHover,
 }: DepartureBoardProps) {
+	const [selectedDestination, setSelectedDestination] = useState<string>("all");
+
+	// 全グループの便を統合し、発車時刻順にソート
+	const allDepartures = useMemo(() => {
+		const deps: (Departure & { toStopName: string; isNextDay?: boolean })[] =
+			[];
+		for (const group of groups) {
+			for (const dep of group.departures) {
+				deps.push({
+					...dep,
+					toStopName: group.toStopName,
+					isNextDay: group.isNextDay,
+				});
+			}
+		}
+		deps.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
+		return deps;
+	}, [groups]);
+
+	// 行先の選択肢
+	const destinations = useMemo(() => {
+		const seen = new Map<string, string>();
+		for (const group of groups) {
+			if (!seen.has(group.toStopId)) {
+				seen.set(group.toStopId, group.toStopName);
+			}
+		}
+		return seen;
+	}, [groups]);
+
+	// フィルタ適用
+	const filteredDepartures = useMemo(() => {
+		if (selectedDestination === "all") return allDepartures;
+		return allDepartures.filter((dep) => dep.toStopId === selectedDestination);
+	}, [allDepartures, selectedDestination]);
+
 	if (!hasRoutes) {
 		return (
 			<div className="card bg-base-100 shadow-sm">
@@ -76,6 +117,10 @@ export function DepartureBoard({
 
 	const allNextDay = groups.length > 0 && groups.every((g) => g.isNextDay);
 
+	// テーブル1行あたりの推定高さ（px）
+	const rowHeight = 40;
+	const maxHeight = rowHeight * VISIBLE_ROWS;
+
 	return (
 		<div className="space-y-4">
 			{lastUpdated && (
@@ -98,17 +143,31 @@ export function DepartureBoard({
 				</div>
 			)}
 
-			{groups.map((group) => (
-				<div key={group.toStopId} className="card bg-base-100 shadow-sm">
+			{groups.length > 0 && (
+				<div className="card bg-base-100 shadow-sm">
 					<div className="card-body">
-						<h3 className="card-title text-lg">
-							{group.toStopName}
-							{group.isNextDay && (
-								<span className="badge badge-outline badge-sm ml-2">
+						<div className="flex items-center gap-3">
+							<h3 className="card-title text-lg">発車案内</h3>
+							{allNextDay && (
+								<span className="badge badge-outline badge-sm">
 									始発以降の便
 								</span>
 							)}
-						</h3>
+							{destinations.size > 1 && (
+								<select
+									className="select select-sm select-bordered"
+									value={selectedDestination}
+									onChange={(e) => setSelectedDestination(e.target.value)}
+								>
+									<option value="all">全ての行先</option>
+									{[...destinations.entries()].map(([stopId, name]) => (
+										<option key={stopId} value={stopId}>
+											{name}
+										</option>
+									))}
+								</select>
+							)}
+						</div>
 						<div className="overflow-x-auto">
 							<table className="table table-sm">
 								<thead>
@@ -122,67 +181,74 @@ export function DepartureBoard({
 										<th>行き先</th>
 									</tr>
 								</thead>
-								<tbody>
-									{group.departures.map((dep) => {
-										const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
-										const isHovered = hoveredRouteKey === routeKey;
-										const agencyColor = getAgencyColor(dep.routeId);
-										return (
-											<tr
-												key={`${dep.tripId}-${dep.departureTime}`}
-												className={`${isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""}`}
-												tabIndex={0}
-												onMouseEnter={() => onRouteHover?.(routeKey)}
-												onMouseLeave={() => onRouteHover?.(null)}
-												onFocus={() => onRouteHover?.(routeKey)}
-												onBlur={() => onRouteHover?.(null)}
-											>
-												<td className="font-mono">
-													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
-													{dep.isDeparted && (
-														<span className="ml-1 badge badge-sm badge-ghost">
-															出発済
-														</span>
-													)}
-												</td>
-												<td>{dep.fromStopName ?? "-"}</td>
-												<td className="font-mono">
-													{formatTime(dep.departureTime)}
-												</td>
-												<td className="font-mono">
-													{formatTime(dep.arrivalTime)}
-												</td>
-												<td>
-													{dep.fare
-														? formatFare(dep.fare.price, dep.fare.currencyType)
-														: "-"}
-												</td>
-												<td>
-													<span className="inline-flex items-center gap-1">
-														{agencyColor && (
-															<span
-																className="inline-block w-3 h-3 rounded-full flex-shrink-0"
-																style={{
-																	backgroundColor: agencyColor.color,
-																}}
-																title={agencyColor.agencyName}
-																aria-label={agencyColor.agencyName}
-																role="img"
-															/>
-														)}
-														{dep.routeName}
-													</span>
-												</td>
-												<td>{dep.headsign}</td>
-											</tr>
-										);
-									})}
-								</tbody>
 							</table>
+							<div
+								className="overflow-y-auto"
+								style={{ maxHeight: `${maxHeight}px` }}
+							>
+								<table className="table table-sm">
+									<tbody>
+										{filteredDepartures.map((dep) => {
+											const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
+											const isHovered = hoveredRouteKey === routeKey;
+											const agencyColor = getAgencyColor(dep.routeId);
+											return (
+												<tr
+													key={`${dep.tripId}-${dep.departureTime}`}
+													className={`${isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""}`}
+													tabIndex={0}
+													onMouseEnter={() => onRouteHover?.(routeKey)}
+													onMouseLeave={() => onRouteHover?.(null)}
+													onFocus={() => onRouteHover?.(routeKey)}
+													onBlur={() => onRouteHover?.(null)}
+												>
+													<td className="font-mono">
+														{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
+														{dep.isDeparted && (
+															<span className="ml-1 badge badge-sm badge-ghost">
+																出発済
+															</span>
+														)}
+													</td>
+													<td>{dep.fromStopName ?? "-"}</td>
+													<td className="font-mono">
+														{formatTime(dep.departureTime)}
+													</td>
+													<td className="font-mono">
+														{formatTime(dep.arrivalTime)}
+													</td>
+													<td>
+														{dep.fare
+															? formatFare(dep.fare.price, dep.fare.currencyType)
+															: "-"}
+													</td>
+													<td>
+														<span className="inline-flex items-center gap-1">
+															{agencyColor && (
+																<span
+																	className="inline-block w-3 h-3 rounded-full flex-shrink-0"
+																	style={{
+																		backgroundColor: agencyColor.color,
+																	}}
+																	title={agencyColor.agencyName}
+																	aria-label={agencyColor.agencyName}
+																	role="img"
+																/>
+															)}
+															{dep.routeName}
+														</span>
+													</td>
+													<td>{dep.headsign}</td>
+												</tr>
+											);
+										})}
+									</tbody>
+								</table>
+							</div>
 						</div>
 					</div>
 				</div>
-			))}
+			)}
 		</div>
 	);
 }

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -54,7 +54,7 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(screen.getByText(/経路が登録されていません/)).toBeInTheDocument();
 	});
 
-	it("降車バス停名がグループ見出しとして表示される", () => {
+	it("行き先が表示される", () => {
 		render(
 			<DepartureBoard
 				groups={[makeGroup()]}
@@ -63,7 +63,8 @@ describe("DepartureBoard コンポーネント", () => {
 				hasRoutes={true}
 			/>,
 		);
-		expect(screen.getByText("市役所前")).toBeInTheDocument();
+		const headsigns = screen.getAllByText("市役所方面");
+		expect(headsigns.length).toBeGreaterThanOrEqual(1);
 	});
 
 	it("発車時刻と到着時刻が HH:MM 形式で表示される", () => {
@@ -94,7 +95,7 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(headsigns.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("複数の降車バス停がそれぞれグルーピングされる", () => {
+	it("複数の行先がプルダウンの選択肢に表示される", () => {
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -124,8 +125,10 @@ describe("DepartureBoard コンポーネント", () => {
 				hasRoutes={true}
 			/>,
 		);
-		expect(screen.getByText("市役所前")).toBeInTheDocument();
-		expect(screen.getByText("旭川四条駅")).toBeInTheDocument();
+		const select = screen.getByRole("combobox");
+		expect(select).toBeInTheDocument();
+		const options = screen.getAllByRole("option");
+		expect(options.length).toBe(3); // 全ての行先 + 市役所前 + 旭川四条駅
 	});
 
 	it("発車予定がない場合はメッセージを表示する", () => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -128,7 +128,17 @@ describe("DepartureBoard コンポーネント", () => {
 		const select = screen.getByRole("combobox");
 		expect(select).toBeInTheDocument();
 		const options = screen.getAllByRole("option");
-		expect(options.length).toBe(3); // 全ての行先 + 市役所前 + 旭川四条駅
+		expect(options).toHaveLength(3);
+		expect(options.map((o) => o.textContent)).toEqual([
+			"全ての行先",
+			"市役所前",
+			"旭川四条駅",
+		]);
+		expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual([
+			"all",
+			"test:S002",
+			"test:S003",
+		]);
 	});
 
 	it("プルダウン選択で行先がフィルタされる", () => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -203,7 +203,7 @@ describe("DepartureBoard コンポーネント", () => {
 		const tbody = screen.getAllByRole("rowgroup")[1]; // tbody
 		const rows = within(tbody).getAllByRole("row");
 		const times = rows.map(
-			(row) => within(row).getAllByText(/^\d{2}:\d{2}$/)[0].textContent,
+			(row) => within(row).getAllByRole("cell")[2].textContent, // 発車カラム（3番目）
 		);
 		// 08:00, 08:15, 09:00 の順に並ぶことを確認
 		expect(times).toEqual(["08:00", "08:15", "09:00"]);

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { DepartureBoard } from "../src/components/DepartureBoard";
 import type { DepartureGroup } from "../src/hooks/useDepartures";
@@ -129,6 +129,84 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(select).toBeInTheDocument();
 		const options = screen.getAllByRole("option");
 		expect(options.length).toBe(3); // 全ての行先 + 市役所前 + 旭川四条駅
+	});
+
+	it("プルダウン選択で行先がフィルタされる", () => {
+		const groups = [
+			makeGroup(),
+			makeGroup({
+				toStopId: "test:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T003",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+
+		const select = screen.getByRole("combobox");
+		fireEvent.change(select, { target: { value: "test:S003" } });
+
+		expect(screen.getByText("四条方面")).toBeInTheDocument();
+		expect(screen.queryByText("市役所方面")).not.toBeInTheDocument();
+	});
+
+	it("複数グループの便が発車時刻順に表示される", () => {
+		const groups = [
+			makeGroup(),
+			makeGroup({
+				toStopId: "test:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T003",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+
+		const tbody = screen.getAllByRole("rowgroup")[1]; // tbody
+		const rows = within(tbody).getAllByRole("row");
+		const times = rows.map(
+			(row) => within(row).getAllByText(/^\d{2}:\d{2}$/)[0].textContent,
+		);
+		// 08:00, 08:15, 09:00 の順に並ぶことを確認
+		expect(times).toEqual(["08:00", "08:15", "09:00"]);
 	});
 
 	it("発車予定がない場合はメッセージを表示する", () => {


### PR DESCRIPTION
## Summary

- 行先ごとに分かれていた複数カードを単一テーブルに統合
- 行先プルダウンで表示切り替え
- 表示を 5 行に制限し、スクロール可能に

## Changes

### テーブル統合
- 全グループの便を発車時刻順にソートして 1 つのテーブルに表示
- 各行に行き先（headsign）列を追加

### 行先プルダウン
- 複数の行先がある場合にプルダウンを表示
- 「全ての行先」+ 各行先の選択肢
- 選択で即座にフィルタリング

### スクロール制限
- テーブルボディを 5 行分の高さに制限（maxHeight: 200px）
- 6 行目以降はスクロールで閲覧可能
- テーブルヘッダーは固定

## Test plan
- [ ] `npm run test` で全 277 テスト通過を確認
- [ ] 複数行先がある場合にプルダウンが表示されることを確認
- [ ] プルダウンで行先を切り替えると表示がフィルタされることを確認
- [ ] 6 行以上ある場合にスクロールバーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 発車案内に目的地フィルタを追加。複数目的地時はドロップダウンで選択して絞り込めます。
  * 目的地が消えた場合は自動的に「全表示」に戻ります。

* **改善**
  * 全出発便を時刻順で統合表示し、一覧がより整然と確認できます。
  * 表示を一つのカード内でスクロール表示、ヘッダを固定して見出しを保持します。

* **テスト**
  * フィルタ操作と表示順序を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->