### PR TITLE
chore: GitHub Actions を Node.js 24 対応版に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: npm
@@ -31,7 +31,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: dist
 
@@ -43,4 +43,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/update-gtfs.yml
+++ b/.github/workflows/update-gtfs.yml
@@ -12,9 +12,9 @@ jobs:
   update-gtfs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: npm
@@ -52,7 +52,7 @@ jobs:
 
       - name: Restore OSM data from cache
         id: osm-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/osm/hokkaido-latest.osm.pbf
           key: osm-hokkaido-

--- a/.github/workflows/update-osm.yml
+++ b/.github/workflows/update-osm.yml
@@ -12,7 +12,7 @@ jobs:
   update-osm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download hokkaido-latest.osm.pbf
         run: |
@@ -42,7 +42,7 @@ jobs:
           rm hokkaido-latest.osm.pbf.md5
 
       - name: Save to cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/osm/hokkaido-latest.osm.pbf
           key: osm-hokkaido-${{ hashFiles('data/osm/hokkaido-latest.osm.pbf') }}


### PR DESCRIPTION
## Summary

Node.js 20 非推奨警告に対応し、全ワークフローのアクションを Node.js 24 対応の最新版に更新

## Changes

| アクション | 旧バージョン | 新バージョン |
|-----------|------------|------------|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v4 |
| actions/deploy-pages | v4 | v5 |
| actions/cache | v4 | v5 |

## 対応した警告

### Node.js 20 非推奨（build / deploy ジョブ）
2026年6月2日以降、Node.js 24 が強制適用される。全アクションを Node.js 24 対応版に更新して解消。

### CodeQL file coverage（Analyze ジョブ）
GitHub 側の仕様変更告知。PR での file coverage 計算が自動スキップされるのみで、対応不要。

## Test plan
- [ ] PR の CI（build / deploy / CodeQL）が警告なしで通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフローのコアアクション（デプロイメント、ノード環境設定、キャッシュ管理）を最新バージョンに更新しました。これにより、開発パイプラインの安定性と信頼性がさらに向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->