### PR TITLE
fix: 行先フィルタの兄弟停留所 ID 不一致と地図の未連動を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,10 +44,19 @@ function App() {
 		setHoveredRouteKey(key);
 	}, []);
 
+	const [selectedDestination, setSelectedDestination] = useState("all");
+	const handleDestinationFilter = useCallback((destinationId: string) => {
+		setSelectedDestination(destinationId);
+	}, []);
+
 	const mapRoutes = useMemo<MapRoute[]>(() => {
 		const seen = new Set<string>();
 		const result: MapRoute[] = [];
-		for (const group of groups) {
+		const filteredGroups =
+			selectedDestination === "all"
+				? groups
+				: groups.filter((g) => g.toStopId === selectedDestination);
+		for (const group of filteredGroups) {
 			for (const dep of group.departures) {
 				const key = `${dep.tripId}-${dep.fromStopId}-${dep.toStopId}`;
 				if (!seen.has(key)) {
@@ -62,7 +71,7 @@ function App() {
 			}
 		}
 		return result;
-	}, [groups]);
+	}, [groups, selectedDestination]);
 
 	return (
 		<div className="min-h-screen bg-base-200">
@@ -93,6 +102,7 @@ function App() {
 							hasRoutes={routes.length > 0}
 							hoveredRouteKey={hoveredRouteKey}
 							onRouteHover={handleRouteHover}
+							onDestinationFilter={handleDestinationFilter}
 						/>
 						{mapRoutes.length > 0 && (
 							<div className="card bg-base-100 shadow-sm">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,17 +45,20 @@ function App() {
 	}, []);
 
 	const [selectedDestination, setSelectedDestination] = useState("all");
-	const handleDestinationFilter = useCallback((destinationId: string) => {
-		setSelectedDestination(destinationId);
-	}, []);
+	const effectiveDestination = useMemo(() => {
+		if (selectedDestination === "all") return "all";
+		return groups.some((g) => g.toStopId === selectedDestination)
+			? selectedDestination
+			: "all";
+	}, [selectedDestination, groups]);
 
 	const mapRoutes = useMemo<MapRoute[]>(() => {
 		const seen = new Set<string>();
 		const result: MapRoute[] = [];
 		const filteredGroups =
-			selectedDestination === "all"
+			effectiveDestination === "all"
 				? groups
-				: groups.filter((g) => g.toStopId === selectedDestination);
+				: groups.filter((g) => g.toStopId === effectiveDestination);
 		for (const group of filteredGroups) {
 			for (const dep of group.departures) {
 				const key = `${dep.tripId}-${dep.fromStopId}-${dep.toStopId}`;
@@ -71,7 +74,7 @@ function App() {
 			}
 		}
 		return result;
-	}, [groups, selectedDestination]);
+	}, [groups, effectiveDestination]);
 
 	return (
 		<div className="min-h-screen bg-base-200">
@@ -102,7 +105,8 @@ function App() {
 							hasRoutes={routes.length > 0}
 							hoveredRouteKey={hoveredRouteKey}
 							onRouteHover={handleRouteHover}
-							onDestinationFilter={handleDestinationFilter}
+							selectedDestination={effectiveDestination}
+							onDestinationChange={setSelectedDestination}
 						/>
 						{mapRoutes.length > 0 && (
 							<div className="card bg-base-100 shadow-sm">

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { DepartureGroup } from "../hooks/useDepartures";
 import { getAgencyColor } from "../lib/agency-colors";
 
@@ -15,6 +15,8 @@ type DepartureBoardProps = {
 	hoveredRouteKey?: string | null;
 	/** 経路ホバー時に呼ばれるコールバック（null でホバー解除） */
 	onRouteHover?: (key: string | null) => void;
+	/** 行先フィルタ変更時に呼ばれるコールバック（"all" で全行先） */
+	onDestinationFilter?: (destinationId: string) => void;
 };
 
 /** HH:MM:SS または H:MM:SS 形式の時刻を HH:MM に短縮する */
@@ -53,6 +55,7 @@ export function DepartureBoard({
 	hasRoutes,
 	hoveredRouteKey,
 	onRouteHover,
+	onDestinationFilter,
 }: DepartureBoardProps) {
 	const [selectedDestination, setSelectedDestination] = useState<string>("all");
 
@@ -62,6 +65,7 @@ export function DepartureBoard({
 			.flatMap((group) =>
 				group.departures.map((dep) => ({
 					...dep,
+					groupToStopId: group.toStopId,
 					toStopName: group.toStopName,
 					isNextDay: group.isNextDay,
 				})),
@@ -86,13 +90,18 @@ export function DepartureBoard({
 			? selectedDestination
 			: "all";
 
-	// フィルタ適用
+	// フィルタ適用（グループの toStopId で比較し、兄弟停留所 ID の不一致を回避）
 	const filteredDepartures = useMemo(() => {
 		if (effectiveSelectedDestination === "all") return allDepartures;
 		return allDepartures.filter(
-			(dep) => dep.toStopId === effectiveSelectedDestination,
+			(dep) => dep.groupToStopId === effectiveSelectedDestination,
 		);
 	}, [allDepartures, effectiveSelectedDestination]);
+
+	// フィルタ変更を親に通知
+	useEffect(() => {
+		onDestinationFilter?.(effectiveSelectedDestination);
+	}, [effectiveSelectedDestination, onDestinationFilter]);
 
 	if (!hasRoutes) {
 		return (

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { DepartureGroup } from "../hooks/useDepartures";
 import { getAgencyColor } from "../lib/agency-colors";
 
@@ -15,8 +15,10 @@ type DepartureBoardProps = {
 	hoveredRouteKey?: string | null;
 	/** 経路ホバー時に呼ばれるコールバック（null でホバー解除） */
 	onRouteHover?: (key: string | null) => void;
-	/** 行先フィルタ変更時に呼ばれるコールバック（"all" で全行先） */
-	onDestinationFilter?: (destinationId: string) => void;
+	/** 現在選択中の行先フィルタ値（"all" で全行先） */
+	selectedDestination?: string;
+	/** 行先フィルタ変更時に呼ばれるコールバック */
+	onDestinationChange?: (destinationId: string) => void;
 };
 
 /** HH:MM:SS または H:MM:SS 形式の時刻を HH:MM に短縮する */
@@ -55,9 +57,9 @@ export function DepartureBoard({
 	hasRoutes,
 	hoveredRouteKey,
 	onRouteHover,
-	onDestinationFilter,
+	selectedDestination = "all",
+	onDestinationChange,
 }: DepartureBoardProps) {
-	const [selectedDestination, setSelectedDestination] = useState<string>("all");
 
 	// 全グループの便を統合し、発車時刻順にソート
 	const allDepartures = useMemo(() => {
@@ -84,24 +86,13 @@ export function DepartureBoard({
 		[groups],
 	);
 
-	// groups 更新後に選択中の行先が消えた場合は "all" にフォールバック
-	const effectiveSelectedDestination =
-		selectedDestination === "all" || destinations.has(selectedDestination)
-			? selectedDestination
-			: "all";
-
 	// フィルタ適用（グループの toStopId で比較し、兄弟停留所 ID の不一致を回避）
 	const filteredDepartures = useMemo(() => {
-		if (effectiveSelectedDestination === "all") return allDepartures;
+		if (selectedDestination === "all") return allDepartures;
 		return allDepartures.filter(
-			(dep) => dep.groupToStopId === effectiveSelectedDestination,
+			(dep) => dep.groupToStopId === selectedDestination,
 		);
-	}, [allDepartures, effectiveSelectedDestination]);
-
-	// フィルタ変更を親に通知
-	useEffect(() => {
-		onDestinationFilter?.(effectiveSelectedDestination);
-	}, [effectiveSelectedDestination, onDestinationFilter]);
+	}, [allDepartures, selectedDestination]);
 
 	if (!hasRoutes) {
 		return (
@@ -165,8 +156,8 @@ export function DepartureBoard({
 								<select
 									aria-label="行き先で絞り込む"
 									className="select select-sm select-bordered"
-									value={effectiveSelectedDestination}
-									onChange={(e) => setSelectedDestination(e.target.value)}
+									value={selectedDestination}
+									onChange={(e) => onDestinationChange?.(e.target.value)}
 								>
 									<option value="all">全ての行先</option>
 									{[...destinations.entries()].map(([stopId, name]) => (

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -61,21 +61,7 @@ export function DepartureBoard({
 	onDestinationChange,
 }: DepartureBoardProps) {
 
-	// 全グループの便を統合し、発車時刻順にソート
-	const allDepartures = useMemo(() => {
-		return groups
-			.flatMap((group) =>
-				group.departures.map((dep) => ({
-					...dep,
-					groupToStopId: group.toStopId,
-					toStopName: group.toStopName,
-					isNextDay: group.isNextDay,
-				})),
-			)
-			.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
-	}, [groups]);
-
-	// 行先の選択肢
+	// 行先の選択肢（ドロップダウン用。フィルタ中も全選択肢を表示する）
 	const destinations = useMemo(
 		() =>
 			new Map(
@@ -86,13 +72,27 @@ export function DepartureBoard({
 		[groups],
 	);
 
-	// フィルタ適用（グループの toStopId で比較し、兄弟停留所 ID の不一致を回避）
-	const filteredDepartures = useMemo(() => {
-		if (selectedDestination === "all") return allDepartures;
-		return allDepartures.filter(
-			(dep) => dep.groupToStopId === selectedDestination,
-		);
-	}, [allDepartures, selectedDestination]);
+	// 選択中の行先でグループを絞り込む
+	const visibleGroups = useMemo(
+		() =>
+			selectedDestination === "all"
+				? groups
+				: groups.filter((g) => g.toStopId === selectedDestination),
+		[groups, selectedDestination],
+	);
+
+	// 表示対象の便を統合し、発車時刻順にソート
+	const allDepartures = useMemo(() => {
+		return visibleGroups
+			.flatMap((group) =>
+				group.departures.map((dep) => ({
+					...dep,
+					toStopName: group.toStopName,
+					isNextDay: group.isNextDay,
+				})),
+			)
+			.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
+	}, [visibleGroups]);
 
 	if (!hasRoutes) {
 		return (
@@ -118,7 +118,8 @@ export function DepartureBoard({
 		);
 	}
 
-	const allNextDay = groups.length > 0 && groups.every((g) => g.isNextDay);
+	const allNextDay =
+		visibleGroups.length > 0 && visibleGroups.every((g) => g.isNextDay);
 
 	return (
 		<div className="space-y-4">
@@ -134,7 +135,7 @@ export function DepartureBoard({
 				}
 			</div>
 
-			{(groups.length === 0 || allNextDay) && (
+			{(visibleGroups.length === 0 || allNextDay) && (
 				<div className="card bg-base-100 shadow-sm">
 					<div className="card-body">
 						<p className="text-base-content/60">現在の発車予定はありません</p>
@@ -184,7 +185,7 @@ export function DepartureBoard({
 									</tr>
 								</thead>
 								<tbody>
-									{filteredDepartures.map((dep) => {
+									{allDepartures.map((dep) => {
 										const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
 										const isHovered = hoveredRouteKey === routeKey;
 										const agencyColor = getAgencyColor(dep.routeId);

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DepartureBoard } from "../src/components/DepartureBoard";
 import type { DepartureGroup } from "../src/hooks/useDepartures";
 
@@ -429,6 +429,103 @@ describe("DepartureBoard コンポーネント", () => {
 			/>,
 		);
 		expect(screen.getByText("旭川駅前")).toBeInTheDocument();
+	});
+
+	it("兄弟停留所 ID が異なってもフィルタで正しく絞り込める", () => {
+		const groups: DepartureGroup[] = [
+			{
+				toStopId: "registered:S002",
+				toStopName: "市役所前",
+				departures: [
+					{
+						tripId: "T001",
+						routeId: "R001",
+						routeName: "1番",
+						headsign: "市役所方面",
+						departureTime: "08:00:00",
+						arrivalTime: "08:30:00",
+						fromStopId: "test:S001",
+						toStopId: "sibling:S002_1",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			},
+			{
+				toStopId: "registered:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T002",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "sibling:S003_1",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			},
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+
+		const select = screen.getByRole("combobox");
+		fireEvent.change(select, { target: { value: "registered:S003" } });
+
+		expect(screen.getByText("四条方面")).toBeInTheDocument();
+		expect(screen.queryByText("市役所方面")).not.toBeInTheDocument();
+	});
+
+	it("onDestinationFilter がフィルタ変更時に呼ばれる", () => {
+		const onFilter = vi.fn();
+		const groups = [
+			makeGroup(),
+			makeGroup({
+				toStopId: "test:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T003",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onDestinationFilter={onFilter}
+			/>,
+		);
+
+		// 初回レンダーで "all" が通知される
+		expect(onFilter).toHaveBeenCalledWith("all");
+
+		const select = screen.getByRole("combobox");
+		fireEvent.change(select, { target: { value: "test:S003" } });
+
+		expect(onFilter).toHaveBeenCalledWith("test:S003");
 	});
 
 	it("Asaca 乗り継ぎ割引の注釈が表示される", () => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -141,7 +141,7 @@ describe("DepartureBoard コンポーネント", () => {
 		]);
 	});
 
-	it("プルダウン選択で行先がフィルタされる", () => {
+	it("selectedDestination で行先がフィルタされる", () => {
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -169,11 +169,9 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
+				selectedDestination="test:S003"
 			/>,
 		);
-
-		const select = screen.getByRole("combobox");
-		fireEvent.change(select, { target: { value: "test:S003" } });
 
 		expect(screen.getByText("四条方面")).toBeInTheDocument();
 		expect(screen.queryByText("市役所方面")).not.toBeInTheDocument();
@@ -476,18 +474,16 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
+				selectedDestination="registered:S003"
 			/>,
 		);
-
-		const select = screen.getByRole("combobox");
-		fireEvent.change(select, { target: { value: "registered:S003" } });
 
 		expect(screen.getByText("四条方面")).toBeInTheDocument();
 		expect(screen.queryByText("市役所方面")).not.toBeInTheDocument();
 	});
 
-	it("onDestinationFilter がフィルタ変更時に呼ばれる", () => {
-		const onFilter = vi.fn();
+	it("onDestinationChange がプルダウン操作で呼ばれる", () => {
+		const onChange = vi.fn();
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -515,17 +511,14 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
-				onDestinationFilter={onFilter}
+				onDestinationChange={onChange}
 			/>,
 		);
-
-		// 初回レンダーで "all" が通知される
-		expect(onFilter).toHaveBeenCalledWith("all");
 
 		const select = screen.getByRole("combobox");
 		fireEvent.change(select, { target: { value: "test:S003" } });
 
-		expect(onFilter).toHaveBeenCalledWith("test:S003");
+		expect(onChange).toHaveBeenCalledWith("test:S003");
 	});
 
 	it("Asaca 乗り継ぎ割引の注釈が表示される", () => {


### PR DESCRIPTION
## Summary

- 行先プルダウンで絞り込むと一覧が空になるバグを修正
- 地図が行先フィルタと連動しない問題を修正

## 原因

- `getSiblingStopIds` が登録バス停 ID を兄弟停留所に展開するため、`Departure.toStopId`（実マッチ ID）と `DepartureGroup.toStopId`（登録 ID）が一致しないケースが発生
- フィルタ状態が DepartureBoard 内部に閉じており、`App.tsx` の `mapRoutes` に反映されなかった

## 修正内容

- `allDepartures` に `groupToStopId`（グループの登録 ID）を追加し、フィルタ条件をそちらに変更
- `onDestinationFilter` コールバック prop を追加し、`App.tsx` で `mapRoutes` をフィルタ

## Test plan

- [x] `npm run test` で全 283 テスト通過を確認
- [ ] ブラウザで行先プルダウン絞り込み時に一覧が正しく表示されることを確認
- [ ] 地図がフィルタと連動し、選択した行先の経路のみ表示されることを確認
- [ ] 「全ての行先」に戻すと全件表示に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 出発案内の目的地選択を外部から制御できるようになり、親からの選択状態と変更通知を受け取れるようになりました。

* **バグ修正**
  * グループ固有の停留所IDを含む場合でも目的地フィルタが正しく動作するよう改善しました。

* **リファクター**
  * 出発案内の状態管理を整理し、フィルタリングの挙動を安定化しました。

* **テスト**
  * 目的地選択とコールバック動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->