### PR TITLE
fix: pfaedle のインストールを apt から Docker イメージに変更

### DIFF
--- a/.github/workflows/update-gtfs.yml
+++ b/.github/workflows/update-gtfs.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Generate shapes with pfaedle
         if: ${{ hashFiles('data/osm/hokkaido-latest.osm.pbf') != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pfaedle
+          docker pull ghcr.io/ad-freiburg/pfaedle:latest
           bash scripts/run-pfaedle.sh data/osm/hokkaido-latest.osm.pbf data/gtfs
 
       - name: Convert GTFS to JSON

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -43,6 +43,7 @@ run_pfaedle() {
   if [ "$USE_DOCKER" = true ]; then
     docker run --rm \
       --user "$(id -u):$(id -g)" \
+      --workdir /data/gtfs \
       -v "$(realpath "$osm_file"):/data/osm.pbf:ro" \
       -v "$(realpath "$gtfs_dir"):/data/gtfs" \
       "$PFAEDLE_IMAGE" \

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -6,6 +6,7 @@ GTFS_BASE="${2:-data/gtfs}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 OPERATORS=("asahikawa_denkikido" "dohoku_bus" "furano_bus")
+PFAEDLE_IMAGE="ghcr.io/ad-freiburg/pfaedle:latest"
 
 # --- OSM ファイル取得 ---
 if [ ! -f "$OSM_FILE" ]; then
@@ -21,12 +22,34 @@ if [ ! -f "$OSM_FILE" ]; then
   echo "Download complete."
 fi
 
-# --- 前提条件チェック ---
-if ! command -v pfaedle &> /dev/null; then
-  echo "Error: pfaedle is not installed"
-  echo "See https://github.com/ad-freiburg/pfaedle for installation instructions"
+# --- pfaedle 実行方法の決定 ---
+USE_DOCKER=false
+if command -v pfaedle &> /dev/null; then
+  echo "Using native pfaedle"
+elif command -v docker &> /dev/null; then
+  echo "pfaedle not found, using Docker image: ${PFAEDLE_IMAGE}"
+  USE_DOCKER=true
+else
+  echo "Error: neither pfaedle nor docker is installed"
+  echo "Install pfaedle (https://github.com/ad-freiburg/pfaedle) or Docker"
   exit 1
 fi
+
+# pfaedle を実行するラッパー関数
+# 引数: pfaedle に渡すオプション（最後の引数が GTFS ディレクトリ）
+run_pfaedle() {
+  local osm_file="$1"
+  local gtfs_dir="$2"
+  if [ "$USE_DOCKER" = true ]; then
+    docker run --rm \
+      -v "$(realpath "$osm_file"):/data/osm.pbf:ro" \
+      -v "$(realpath "$gtfs_dir"):/data/gtfs" \
+      "$PFAEDLE_IMAGE" \
+      -D -x --osm-file /data/osm.pbf /data/gtfs
+  else
+    pfaedle -D -x --osm-file "$osm_file" "$gtfs_dir"
+  fi
+}
 
 # --- 各事業者の shapes.txt 生成 ---
 has_error=false
@@ -42,7 +65,7 @@ for operator in "${OPERATORS[@]}"; do
   fi
 
   echo "Generating shapes for ${operator}..."
-  if ! pfaedle -D -x --osm-file "$OSM_FILE" "$gtfs_dir"; then
+  if ! run_pfaedle "$OSM_FILE" "$gtfs_dir"; then
     echo "Error: pfaedle failed for ${operator}"
     has_error=true
     continue

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -36,12 +36,13 @@ else
 fi
 
 # pfaedle を実行するラッパー関数
-# 引数: pfaedle に渡すオプション（最後の引数が GTFS ディレクトリ）
+# 引数: 1: OSMファイルパス, 2: GTFSディレクトリパス
 run_pfaedle() {
   local osm_file="$1"
   local gtfs_dir="$2"
   if [ "$USE_DOCKER" = true ]; then
     docker run --rm \
+      --user "$(id -u):$(id -g)" \
       -v "$(realpath "$osm_file"):/data/osm.pbf:ro" \
       -v "$(realpath "$gtfs_dir"):/data/gtfs" \
       "$PFAEDLE_IMAGE" \


### PR DESCRIPTION
## Summary

- `update-gtfs` ワークフローで `apt-get install -y pfaedle` が `E: Unable to locate package pfaedle` で失敗する問題を修正
- pfaedle の実行を Docker イメージ `ghcr.io/ad-freiburg/pfaedle:latest` に切り替え

## 原因

pfaedle は Ubuntu の標準 apt リポジトリに存在しない。

## 修正内容

- `scripts/run-pfaedle.sh`: ネイティブ pfaedle がなければ Docker にフォールバックする `run_pfaedle` ラッパー関数を導入
- `.github/workflows/update-gtfs.yml`: `apt-get install` を `docker pull` に置換

## Test plan

- [ ] マージ後に `workflow_dispatch` で `Update GTFS Data` を手動実行し成功を確認
- [ ] shapes.txt が各事業者ディレクトリに生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)