### PR TITLE
fix: Docker 版 pfaedle のコマンド引数を正しい構文に修正

### DIFF
--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -43,11 +43,11 @@ run_pfaedle() {
   if [ "$USE_DOCKER" = true ]; then
     docker run --rm \
       --user "$(id -u):$(id -g)" \
-      --workdir /data/gtfs \
-      -v "$(realpath "$osm_file"):/data/osm.pbf:ro" \
-      -v "$(realpath "$gtfs_dir"):/data/gtfs" \
+      --workdir /gtfs \
+      -v "$(realpath "$osm_file"):/osm/input.osm.pbf:ro" \
+      -v "$(realpath "$gtfs_dir"):/gtfs" \
       "$PFAEDLE_IMAGE" \
-      -D -x --osm-file /data/osm.pbf /data/gtfs
+      -D -x /osm/input.osm.pbf /gtfs
   else
     pfaedle -D -x --osm-file "$osm_file" "$gtfs_dir"
   fi

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -49,7 +49,7 @@ run_pfaedle() {
       "$PFAEDLE_IMAGE" \
       -D -x /osm/input.osm.pbf /gtfs
   else
-    pfaedle -D -x --osm-file "$osm_file" "$gtfs_dir"
+    pfaedle -D -x "$osm_file" "$gtfs_dir"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Docker イメージの pfaedle で `Multiple feeds only allowed in filter mode` エラーが発生する問題を修正

## 原因

Docker イメージの pfaedle では `-x` が OSM ファイルを指定するオプション。`-x --osm-file /data/osm.pbf /data/gtfs` と書くと `-x` が `--osm-file` という文字列をファイル名と解釈し、残りの `/data/osm.pbf` と `/data/gtfs` が 2 つの GTFS フィードとみなされエラーになる。

## 修正内容

- Docker 実行時のコマンドを `-D -x /osm/input.osm.pbf /gtfs` に変更
- マウントパスを pfaedle 公式ドキュメントに合わせて `/osm`, `/gtfs` に変更

## Test plan

- [ ] マージ後に `workflow_dispatch` で `Update GTFS Data` を手動実行し成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)