### PR TITLE
feat: バス停検索結果に事業者カラーバッジを追加

### DIFF
--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { Database } from "sql.js";
+import { getAgencyColor } from "../lib/agency-colors";
 import { type StopSearchResult, searchStops } from "../lib/stop-search";
 
 type StopSearchProps = {
@@ -153,7 +154,28 @@ export function StopSearch({
 							onClick={() => handleSelect(stop)}
 							onMouseEnter={() => setActiveIndex(index)}
 						>
-							{stop.stop_name}
+							<span className="inline-flex items-center gap-1">
+								{stop.stop_name}
+								{(() => {
+									const ids = stop.clusterStopIds ?? [stop.stop_id];
+									const seen = new Set<string>();
+									return ids.flatMap((id) => {
+										const entry = getAgencyColor(id);
+										if (!entry || seen.has(entry.agencyName)) return [];
+										seen.add(entry.agencyName);
+										return (
+											<span
+												key={entry.agencyName}
+												className="inline-block w-3 h-3 rounded-full flex-shrink-0"
+												style={{ backgroundColor: entry.color }}
+												title={entry.agencyName}
+												aria-label={entry.agencyName}
+												role="img"
+											/>
+										);
+									});
+								})()}
+							</span>
 							{stop.disambiguationLabel && (
 								<span className="text-xs text-base-content/60 ml-1">
 									({stop.disambiguationLabel})

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -154,10 +154,10 @@ export function StopSearch({
 							onClick={() => handleSelect(stop)}
 							onMouseEnter={() => setActiveIndex(index)}
 						>
-							<span className="inline-flex items-center gap-1">
+							<span className="inline-flex flex-wrap items-center gap-1">
 								{stop.stop_name}
 								{(() => {
-									const ids = stop.clusterStopIds ?? [stop.stop_id];
+									const ids = stop.clusterStopIds;
 									const seen = new Set<string>();
 									return ids.flatMap((id) => {
 										const entry = getAgencyColor(id);

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -7,6 +7,8 @@ export type StopSearchResult = {
 	stop_name: string;
 	/** 同名バス停が遠距離に存在する場合の区別ラベル（事業者名など） */
 	disambiguationLabel?: string;
+	/** クラスタに含まれる全バス停の stop_id（事業者バッジ表示用） */
+	clusterStopIds?: string[];
 };
 
 /** 検索結果の最大件数 */
@@ -75,6 +77,10 @@ export function searchStops(
 				stop_id: cluster.representativeId,
 				stop_name: cluster.stopName,
 			};
+
+			if (cluster.stopIds.length > 1) {
+				result.clusterStopIds = cluster.stopIds;
+			}
 
 			if (needsDisambiguation.has(cluster.stopName)) {
 				result.disambiguationLabel = resolveDisambiguationLabel(

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -8,7 +8,7 @@ export type StopSearchResult = {
 	/** 同名バス停が遠距離に存在する場合の区別ラベル（事業者名など） */
 	disambiguationLabel?: string;
 	/** クラスタに含まれる全バス停の stop_id（事業者バッジ表示用） */
-	clusterStopIds?: string[];
+	clusterStopIds: string[];
 };
 
 /** 検索結果の最大件数 */
@@ -76,11 +76,8 @@ export function searchStops(
 			const result: StopSearchResult = {
 				stop_id: cluster.representativeId,
 				stop_name: cluster.stopName,
+				clusterStopIds: cluster.stopIds,
 			};
-
-			if (cluster.stopIds.length > 1) {
-				result.clusterStopIds = cluster.stopIds;
-			}
 
 			if (needsDisambiguation.has(cluster.stopName)) {
 				result.disambiguationLabel = resolveDisambiguationLabel(

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -128,6 +128,7 @@ describe("StopSearch コンポーネント", () => {
 		expect(onSelect).toHaveBeenCalledWith({
 			stop_id: "test:S002",
 			stop_name: "市役所前",
+			clusterStopIds: ["test:S002"],
 		});
 		expect(input).toHaveValue("市役所前");
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -180,6 +180,7 @@ describe("StopSearch コンポーネント", () => {
 		const selected: StopSearchResult = {
 			stop_id: "test:S001",
 			stop_name: "旭川駅前",
+			clusterStopIds: ["test:S001"],
 		};
 		render(
 			<StopSearch


### PR DESCRIPTION
## Summary

- 経路登録のバス停検索結果に、発車案内と同じ事業者カラーバッジを表示
- 複数事業者が乗り入れるバス停には全事業者のバッジを表示

## 変更内容

- `StopSearchResult` に `clusterStopIds` フィールドを追加し、クラスタ内の全 `stop_id` を保持
- `StopSearch.tsx` でユニークな事業者を抽出し、バス停名の後ろにバッジを表示
- 既存の `getAgencyColor` を再利用（DepartureBoard と同一パターン）

## Test plan

- [x] `npm run test` で全 283 テスト通過を確認
- [ ] バス停検索結果にカラーバッジが表示されることを確認
- [ ] 複数事業者が乗り入れるバス停（例: 旭川駅前）に複数バッジが表示されることを確認
- [ ] ホバーで事業者名のツールチップが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 停留所検索結果に、各停留所に対応する交通機関を示す色付き円形インジケーターを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->