### PR TITLE
fix: RouteRegistration の StopSearchResult に clusterStopIds を追加

### DIFF
--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -124,10 +124,12 @@ export function RouteRegistration({
 				fromStop: {
 					stop_id: route.fromStopId,
 					stop_name: stopNameMap.get(route.fromStopId) ?? route.fromStopId,
+					clusterStopIds: [route.fromStopId],
 				},
 				toStop: {
 					stop_id: route.toStopId,
 					stop_name: stopNameMap.get(route.toStopId) ?? route.toStopId,
+					clusterStopIds: [route.toStopId],
 				},
 				walkMinutes: String(route.walkMinutes),
 			});


### PR DESCRIPTION
## Summary

- `clusterStopIds` 必須化に伴い、`RouteRegistration.tsx` の `handleEdit` 内で構築する `StopSearchResult` リテラルにフィールドを追加
- デプロイワークフローのビルドエラー（TS2741）を修正

## Test plan

- [x] `npm run build` で型チェック通過を確認
- [x] `npm run test` で全 283 テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)