### PR TITLE
fix: pfaedle による fare ファイルの上書きを防止

### DIFF
--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -54,6 +54,9 @@ run_pfaedle() {
 }
 
 # --- 各事業者の shapes.txt 生成 ---
+# pfaedle は -o で出力時に GTFS 全ファイルを上書きするため、
+# pfaedle が生成しないファイルを退避して復元する
+PRESERVE_FILES=(fare_attributes.txt fare_rules.txt feed_info.txt translations.txt attributions.txt)
 has_error=false
 processed=0
 
@@ -68,9 +71,6 @@ for operator in "${OPERATORS[@]}"; do
 
   echo "Generating shapes for ${operator}..."
 
-  # pfaedle は -o で出力時に GTFS 全ファイルを上書きするため、
-  # pfaedle が生成しないファイルを退避して復元する
-  PRESERVE_FILES=(fare_attributes.txt fare_rules.txt feed_info.txt translations.txt)
   backup_dir=$(mktemp -d)
   for f in "${PRESERVE_FILES[@]}"; do
     if [ -f "${gtfs_dir}/${f}" ]; then

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -74,7 +74,7 @@ for operator in "${OPERATORS[@]}"; do
   backup_dir=$(mktemp -d)
   for f in "${PRESERVE_FILES[@]}"; do
     if [ -f "${gtfs_dir}/${f}" ]; then
-      cp "${gtfs_dir}/${f}" "${backup_dir}/${f}"
+      cp -p "${gtfs_dir}/${f}" "${backup_dir}/${f}"
     fi
   done
 
@@ -88,7 +88,7 @@ for operator in "${OPERATORS[@]}"; do
   # 成功・失敗に関わらず退避したファイルを復元
   for f in "${PRESERVE_FILES[@]}"; do
     if [ -f "${backup_dir}/${f}" ]; then
-      cp "${backup_dir}/${f}" "${gtfs_dir}/${f}"
+      cp -p "${backup_dir}/${f}" "${gtfs_dir}/${f}"
     fi
   done
   rm -rf "$backup_dir"

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -69,28 +69,33 @@ for operator in "${OPERATORS[@]}"; do
   echo "Generating shapes for ${operator}..."
 
   # pfaedle は -o で出力時に GTFS 全ファイルを上書きするため、
-  # shapes.txt 以外のファイルを退避して復元する
+  # pfaedle が生成しないファイルを退避して復元する
+  PRESERVE_FILES=(fare_attributes.txt fare_rules.txt feed_info.txt translations.txt)
   backup_dir=$(mktemp -d)
-  for f in fare_attributes.txt fare_rules.txt; do
+  for f in "${PRESERVE_FILES[@]}"; do
     if [ -f "${gtfs_dir}/${f}" ]; then
       cp "${gtfs_dir}/${f}" "${backup_dir}/${f}"
     fi
   done
 
+  pfaedle_ok=true
   if ! run_pfaedle "$OSM_FILE" "$gtfs_dir"; then
     echo "Error: pfaedle failed for ${operator}"
-    rm -rf "$backup_dir"
+    pfaedle_ok=false
     has_error=true
-    continue
   fi
 
-  # 退避したファイルを復元
-  for f in fare_attributes.txt fare_rules.txt; do
+  # 成功・失敗に関わらず退避したファイルを復元
+  for f in "${PRESERVE_FILES[@]}"; do
     if [ -f "${backup_dir}/${f}" ]; then
       cp "${backup_dir}/${f}" "${gtfs_dir}/${f}"
     fi
   done
   rm -rf "$backup_dir"
+
+  if [ "$pfaedle_ok" = false ]; then
+    continue
+  fi
 
   shapes_file="${gtfs_dir}/shapes.txt"
   if [ ! -f "$shapes_file" ]; then

--- a/scripts/run-pfaedle.sh
+++ b/scripts/run-pfaedle.sh
@@ -67,11 +67,30 @@ for operator in "${OPERATORS[@]}"; do
   fi
 
   echo "Generating shapes for ${operator}..."
+
+  # pfaedle は -o で出力時に GTFS 全ファイルを上書きするため、
+  # shapes.txt 以外のファイルを退避して復元する
+  backup_dir=$(mktemp -d)
+  for f in fare_attributes.txt fare_rules.txt; do
+    if [ -f "${gtfs_dir}/${f}" ]; then
+      cp "${gtfs_dir}/${f}" "${backup_dir}/${f}"
+    fi
+  done
+
   if ! run_pfaedle "$OSM_FILE" "$gtfs_dir"; then
     echo "Error: pfaedle failed for ${operator}"
+    rm -rf "$backup_dir"
     has_error=true
     continue
   fi
+
+  # 退避したファイルを復元
+  for f in fare_attributes.txt fare_rules.txt; do
+    if [ -f "${backup_dir}/${f}" ]; then
+      cp "${backup_dir}/${f}" "${gtfs_dir}/${f}"
+    fi
+  done
+  rm -rf "$backup_dir"
 
   shapes_file="${gtfs_dir}/shapes.txt"
   if [ ! -f "$shapes_file" ]; then


### PR DESCRIPTION
## Summary

- pfaedle が `-o` で GTFS 全ファイルを上書きするため、`fare_attributes.txt` と `fare_rules.txt` が空になっていた問題を修正
- pfaedle 実行前に fare ファイルを退避し、実行後に復元する処理を追加

## 原因

pfaedle は shapes.txt の生成だけでなく、出力先ディレクトリに完全な GTFS フィードを書き出す。`-o /gtfs` で入力ディレクトリを出力先に指定しているため、元の fare ファイルが空のファイルで上書きされていた。

## Test plan

- [ ] マージ後に `workflow_dispatch` で `Update GTFS Data` を実行
- [ ] 3 事業者の fare_attributes / fare_rules が 0 件でないことを確認
- [ ] ブラウザで道北バス・ふらのバスの運賃が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スクリプト実行時の重要ファイル保護メカニズムを追加し、処理中のデータ整合性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->