### PR TITLE
fix: GTFS データ更新後にデプロイを自動トリガー

### DIFF
--- a/.github/workflows/update-gtfs.yml
+++ b/.github/workflows/update-gtfs.yml
@@ -115,3 +115,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: update GTFS data $(date -u +%Y-%m-%d)"
           git push
+
+      - name: Trigger deploy
+        if: steps.diff.outputs.changed == 'true'
+        run: gh workflow run deploy.yml
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- GTFS データ更新後に GitHub Pages へのデプロイが自動実行されない問題を修正
- `update-gtfs.yml` のコミット後に `gh workflow run deploy.yml` を呼び出す

## 原因

GitHub Actions の `GITHUB_TOKEN` による push は、セキュリティ上の制限で他のワークフローをトリガーしない。GTFS データが更新・コミットされても、デプロイワークフローが起動せず、古いデータのまま公開されていた。

## Test plan

- [ ] マージ後に `workflow_dispatch` で `Update GTFS Data` を実行
- [ ] データ変更時にデプロイが自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)