### PR TITLE
feat: ルートキーに routeId を追加し、ハイライト固定と z-order 対応

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,12 @@ function App() {
 		setHoveredRouteKey(key);
 	}, []);
 
+	const [pinnedRouteKey, setPinnedRouteKey] = useState<string | null>(null);
+	const handleRoutePinToggle = useCallback((key: string) => {
+		setPinnedRouteKey((prev) => (prev === key ? null : key));
+	}, []);
+
+
 	const [selectedDestination, setSelectedDestination] = useState("all");
 	const effectiveDestination = useMemo(() => {
 		if (selectedDestination === "all") return "all";
@@ -66,6 +72,7 @@ function App() {
 					seen.add(key);
 					result.push({
 						tripId: dep.tripId,
+						routeId: dep.routeId,
 						shapeId: dep.shapeId ?? undefined,
 						fromStopId: dep.fromStopId,
 						toStopId: dep.toStopId,
@@ -105,6 +112,8 @@ function App() {
 							hasRoutes={routes.length > 0}
 							hoveredRouteKey={hoveredRouteKey}
 							onRouteHover={handleRouteHover}
+							pinnedRouteKey={pinnedRouteKey}
+							onRoutePinToggle={handleRoutePinToggle}
 							selectedDestination={effectiveDestination}
 							onDestinationChange={setSelectedDestination}
 						/>
@@ -117,6 +126,8 @@ function App() {
 										routes={mapRoutes}
 										onRouteHover={handleRouteHover}
 										hoveredRouteKey={hoveredRouteKey}
+										pinnedRouteKey={pinnedRouteKey}
+										onRoutePinToggle={handleRoutePinToggle}
 									/>
 								</div>
 							</div>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -11,10 +11,14 @@ type DepartureBoardProps = {
 	error: Error | null;
 	/** 経路が登録されているかどうか */
 	hasRoutes: boolean;
-	/** 地図上でホバー中の経路キー（fromStopId-toStopId） */
+	/** ホバーまたは固定中の経路キー */
 	hoveredRouteKey?: string | null;
 	/** 経路ホバー時に呼ばれるコールバック（null でホバー解除） */
 	onRouteHover?: (key: string | null) => void;
+	/** 固定中の経路キー */
+	pinnedRouteKey?: string | null;
+	/** 経路クリック時のトグルコールバック */
+	onRoutePinToggle?: (key: string) => void;
 	/** 現在選択中の行先フィルタ値（"all" で全行先） */
 	selectedDestination?: string;
 	/** 行先フィルタ変更時に呼ばれるコールバック */
@@ -57,6 +61,8 @@ export function DepartureBoard({
 	hasRoutes,
 	hoveredRouteKey,
 	onRouteHover,
+	pinnedRouteKey,
+	onRoutePinToggle,
 	selectedDestination = "all",
 	onDestinationChange,
 }: DepartureBoardProps) {
@@ -186,18 +192,20 @@ export function DepartureBoard({
 								</thead>
 								<tbody>
 									{allDepartures.map((dep) => {
-										const routeKey = `${dep.fromStopId}-${dep.toStopId}`;
+										const routeKey = `${dep.routeId}-${dep.fromStopId}-${dep.toStopId}`;
 										const isHovered = hoveredRouteKey === routeKey;
+										const isPinned = pinnedRouteKey === routeKey;
 										const agencyColor = getAgencyColor(dep.routeId);
 										return (
 											<tr
 												key={`${dep.tripId}-${dep.departureTime}`}
-												className={`${isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""}`}
+												className={`${isPinned ? "bg-info/20" : isHovered ? "bg-info/10" : ""} ${dep.isDeparted ? "opacity-50" : ""} cursor-pointer`}
 												tabIndex={0}
 												onMouseEnter={() => onRouteHover?.(routeKey)}
 												onMouseLeave={() => onRouteHover?.(null)}
 												onFocus={() => onRouteHover?.(routeKey)}
 												onBlur={() => onRouteHover?.(null)}
+												onClick={() => onRoutePinToggle?.(routeKey)}
 											>
 												<td className="font-mono">
 													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -206,6 +206,12 @@ export function DepartureBoard({
 												onFocus={() => onRouteHover?.(routeKey)}
 												onBlur={() => onRouteHover?.(null)}
 												onClick={() => onRoutePinToggle?.(routeKey)}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" || e.key === " ") {
+														e.preventDefault();
+														onRoutePinToggle?.(routeKey);
+													}
+												}}
 											>
 												<td className="font-mono">
 													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -278,19 +278,14 @@ function MapView({
 			{/* ハイライト区間（アクティブなものを最前面に表示するためにソート） */}
 			{[...highlightPolylines]
 				.sort((a, b) => {
-					const aActive =
-						hoveredKey === a.key ||
-						hoveredRouteKey === a.routeKey ||
-						pinnedRouteKey === a.routeKey
-							? 1
-							: 0;
-					const bActive =
-						hoveredKey === b.key ||
-						hoveredRouteKey === b.routeKey ||
-						pinnedRouteKey === b.routeKey
-							? 1
-							: 0;
-					return aActive - bActive;
+					// 0=非アクティブ, 1=固定, 2=ホバー（ホバーが最前面）
+					const priority = (pl: HighlightPolylineData) => {
+						if (hoveredKey === pl.key || hoveredRouteKey === pl.routeKey)
+							return 2;
+						if (pinnedRouteKey === pl.routeKey) return 1;
+						return 0;
+					};
+					return priority(a) - priority(b);
 				})
 				.map((pl) => {
 					const isActive =

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -275,52 +275,51 @@ function MapView({
 					}}
 				/>
 			))}
-			{/* 非アクティブなハイライト区間を先に描画 */}
-			{highlightPolylines
-				.filter((pl) => hoveredKey !== pl.key && hoveredRouteKey !== pl.routeKey && pinnedRouteKey !== pl.routeKey)
-				.map((pl) => (
-					<Polyline
-						key={`hl-${pl.key}`}
-						positions={pl.positions}
-						pathOptions={{
-							color: ROUTE_COLOR_SECTION,
-							weight: SECTION_WEIGHT,
-							opacity: 0.9,
-						}}
-						eventHandlers={{
-							mouseover: () => handleMouseOver(pl.key),
-							mouseout: handleMouseOut,
-							click: () => handleClick(pl.key),
-						}}
-					>
-						<Tooltip sticky>
-							{pl.fromStopName} → {pl.toStopName}
-						</Tooltip>
-					</Polyline>
-				))}
-			{/* アクティブなハイライト区間を後に描画（最前面） */}
-			{highlightPolylines
-				.filter((pl) => hoveredKey === pl.key || hoveredRouteKey === pl.routeKey || pinnedRouteKey === pl.routeKey)
-				.map((pl) => (
-					<Polyline
-						key={`hl-${pl.key}`}
-						positions={pl.positions}
-						pathOptions={{
-							color: ROUTE_COLOR_SECTION_HOVER,
-							weight: SECTION_WEIGHT,
-							opacity: 0.9,
-						}}
-						eventHandlers={{
-							mouseover: () => handleMouseOver(pl.key),
-							mouseout: handleMouseOut,
-							click: () => handleClick(pl.key),
-						}}
-					>
-						<Tooltip sticky>
-							{pl.fromStopName} → {pl.toStopName}
-						</Tooltip>
-					</Polyline>
-				))}
+			{/* ハイライト区間（アクティブなものを最前面に表示するためにソート） */}
+			{[...highlightPolylines]
+				.sort((a, b) => {
+					const aActive =
+						hoveredKey === a.key ||
+						hoveredRouteKey === a.routeKey ||
+						pinnedRouteKey === a.routeKey
+							? 1
+							: 0;
+					const bActive =
+						hoveredKey === b.key ||
+						hoveredRouteKey === b.routeKey ||
+						pinnedRouteKey === b.routeKey
+							? 1
+							: 0;
+					return aActive - bActive;
+				})
+				.map((pl) => {
+					const isActive =
+						hoveredKey === pl.key ||
+						hoveredRouteKey === pl.routeKey ||
+						pinnedRouteKey === pl.routeKey;
+					return (
+						<Polyline
+							key={`hl-${pl.key}`}
+							positions={pl.positions}
+							pathOptions={{
+								color: isActive
+									? ROUTE_COLOR_SECTION_HOVER
+									: ROUTE_COLOR_SECTION,
+								weight: SECTION_WEIGHT,
+								opacity: 0.9,
+							}}
+							eventHandlers={{
+								mouseover: () => handleMouseOver(pl.key),
+								mouseout: handleMouseOut,
+								click: () => handleClick(pl.key),
+							}}
+						>
+							<Tooltip sticky>
+								{pl.fromStopName} → {pl.toStopName}
+							</Tooltip>
+						</Polyline>
+					);
+				})}
 		</MapContainer>
 	);
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -45,6 +45,7 @@ const SECTION_WEIGHT = 10;
 
 type MapRoute = {
 	tripId: string;
+	routeId: string;
 	shapeId?: string;
 	fromStopId: string;
 	toStopId: string;
@@ -55,8 +56,12 @@ type MapViewProps = {
 	routes: MapRoute[];
 	/** 経路ホバー時に呼ばれるコールバック（null でホバー解除） */
 	onRouteHover?: (key: string | null) => void;
-	/** 外部からのホバー中経路キー（fromStopId-toStopId） */
+	/** ホバーまたは固定中の経路キー */
 	hoveredRouteKey?: string | null;
+	/** 固定中の経路キー */
+	pinnedRouteKey?: string | null;
+	/** 経路クリック時のトグルコールバック */
+	onRoutePinToggle?: (key: string) => void;
 };
 
 type PolylineData = {
@@ -94,7 +99,14 @@ function getStopInfo(
 	}
 }
 
-function MapView({ db, routes, onRouteHover, hoveredRouteKey }: MapViewProps) {
+function MapView({
+	db,
+	routes,
+	onRouteHover,
+	hoveredRouteKey,
+	pinnedRouteKey,
+	onRoutePinToggle,
+}: MapViewProps) {
 	const { markers, basePolylines, highlightPolylines } = useMemo(() => {
 		const markersMap = new Map<
 			string,
@@ -174,7 +186,7 @@ function MapView({ db, routes, onRouteHover, hoveredRouteKey }: MapViewProps) {
 				if (segment.length > 0) {
 					highlightArr.push({
 						key: highlightKey,
-						routeKey: `${route.fromStopId}-${route.toStopId}`,
+						routeKey: `${route.routeId}-${route.fromStopId}-${route.toStopId}`,
 						positions: segment,
 						fromStopName: fromStop.name,
 						toStopName: toStop.name,
@@ -202,6 +214,19 @@ function MapView({ db, routes, onRouteHover, hoveredRouteKey }: MapViewProps) {
 
 	const onRouteHoverRef = useRef(onRouteHover);
 	onRouteHoverRef.current = onRouteHover;
+
+	const onRoutePinToggleRef = useRef(onRoutePinToggle);
+	onRoutePinToggleRef.current = onRoutePinToggle;
+
+	const handleClick = useCallback(
+		(key: string) => {
+			const routeKey = routeKeyMap.get(key);
+			if (routeKey) {
+				onRoutePinToggleRef.current?.(routeKey);
+			}
+		},
+		[routeKeyMap],
+	);
 
 	const handleMouseOver = useCallback(
 		(key: string) => {
@@ -250,29 +275,52 @@ function MapView({ db, routes, onRouteHover, hoveredRouteKey }: MapViewProps) {
 					}}
 				/>
 			))}
-			{highlightPolylines.map((pl) => {
-				const isActive =
-					hoveredKey === pl.key || hoveredRouteKey === pl.routeKey;
-				return (
+			{/* 非アクティブなハイライト区間を先に描画 */}
+			{highlightPolylines
+				.filter((pl) => hoveredKey !== pl.key && hoveredRouteKey !== pl.routeKey && pinnedRouteKey !== pl.routeKey)
+				.map((pl) => (
 					<Polyline
 						key={`hl-${pl.key}`}
 						positions={pl.positions}
 						pathOptions={{
-							color: isActive ? ROUTE_COLOR_SECTION_HOVER : ROUTE_COLOR_SECTION,
+							color: ROUTE_COLOR_SECTION,
 							weight: SECTION_WEIGHT,
 							opacity: 0.9,
 						}}
 						eventHandlers={{
 							mouseover: () => handleMouseOver(pl.key),
 							mouseout: handleMouseOut,
+							click: () => handleClick(pl.key),
 						}}
 					>
 						<Tooltip sticky>
 							{pl.fromStopName} → {pl.toStopName}
 						</Tooltip>
 					</Polyline>
-				);
-			})}
+				))}
+			{/* アクティブなハイライト区間を後に描画（最前面） */}
+			{highlightPolylines
+				.filter((pl) => hoveredKey === pl.key || hoveredRouteKey === pl.routeKey || pinnedRouteKey === pl.routeKey)
+				.map((pl) => (
+					<Polyline
+						key={`hl-${pl.key}`}
+						positions={pl.positions}
+						pathOptions={{
+							color: ROUTE_COLOR_SECTION_HOVER,
+							weight: SECTION_WEIGHT,
+							opacity: 0.9,
+						}}
+						eventHandlers={{
+							mouseover: () => handleMouseOver(pl.key),
+							mouseout: handleMouseOut,
+							click: () => handleClick(pl.key),
+						}}
+					>
+						<Tooltip sticky>
+							{pl.fromStopName} → {pl.toStopName}
+						</Tooltip>
+					</Polyline>
+				))}
 		</MapContainer>
 	);
 }

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -521,6 +521,135 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(onChange).toHaveBeenCalledWith("test:S003");
 	});
 
+	it("ホバー時に onRouteHover が routeId を含むキーで呼ばれる", async () => {
+		const onHover = vi.fn();
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onRouteHover={onHover}
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		// thead の行を除いた最初のデータ行
+		const dataRow = rows[1];
+		fireEvent.mouseEnter(dataRow);
+		// routeId-fromStopId-toStopId 形式であること
+		expect(onHover).toHaveBeenCalledWith("R001-test:S001-test:S002");
+	});
+
+	it("異なる routeId の便は別のルートキーを持つ", async () => {
+		const onHover = vi.fn();
+		const groups: DepartureGroup[] = [
+			{
+				toStopId: "test:S002",
+				toStopName: "市役所前",
+				departures: [
+					{
+						tripId: "T001",
+						routeId: "R001",
+						routeName: "1番",
+						headsign: "市役所方面",
+						departureTime: "08:00:00",
+						arrivalTime: "08:30:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S002",
+						shapeId: null,
+						fare: null,
+					},
+					{
+						tripId: "T002",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "市役所方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S002",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			},
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onRouteHover={onHover}
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		fireEvent.mouseEnter(rows[1]); // R001 の行
+		expect(onHover).toHaveBeenCalledWith("R001-test:S001-test:S002");
+		fireEvent.mouseEnter(rows[2]); // R002 の行
+		expect(onHover).toHaveBeenCalledWith("R002-test:S001-test:S002");
+	});
+
+	it("クリックで onRoutePinToggle が呼ばれる", () => {
+		const onPin = vi.fn();
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onRoutePinToggle={onPin}
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		fireEvent.click(rows[1]);
+		expect(onPin).toHaveBeenCalledWith("R001-test:S001-test:S002");
+	});
+
+	it("pinnedRouteKey に一致する行に固定スタイルが適用される", () => {
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				pinnedRouteKey="R001-test:S001-test:S002"
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		expect(rows[1].className).toContain("bg-info/20");
+	});
+
+	it("hoveredRouteKey に一致する行にホバースタイルが適用される", () => {
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				hoveredRouteKey="R001-test:S001-test:S002"
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		expect(rows[1].className).toContain("bg-info/10");
+	});
+
+	it("固定とホバーが同時にある場合、固定スタイルが優先される", () => {
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				pinnedRouteKey="R001-test:S001-test:S002"
+				hoveredRouteKey="R001-test:S001-test:S002"
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		expect(rows[1].className).toContain("bg-info/20");
+		expect(rows[1].className).not.toContain("bg-info/10");
+	});
+
 	it("Asaca 乗り継ぎ割引の注釈が表示される", () => {
 		render(
 			<DepartureBoard

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -606,6 +606,38 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(onPin).toHaveBeenCalledWith("R001-test:S001-test:S002");
 	});
 
+	it("Enter キーで onRoutePinToggle が呼ばれる", () => {
+		const onPin = vi.fn();
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onRoutePinToggle={onPin}
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		fireEvent.keyDown(rows[1], { key: "Enter" });
+		expect(onPin).toHaveBeenCalledWith("R001-test:S001-test:S002");
+	});
+
+	it("Space キーで onRoutePinToggle が呼ばれる", () => {
+		const onPin = vi.fn();
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				onRoutePinToggle={onPin}
+			/>,
+		);
+		const rows = screen.getAllByRole("row");
+		fireEvent.keyDown(rows[1], { key: " " });
+		expect(onPin).toHaveBeenCalledWith("R001-test:S001-test:S002");
+	});
+
 	it("pinnedRouteKey に一致する行に固定スタイルが適用される", () => {
 		render(
 			<DepartureBoard

--- a/test/MapView.test.tsx
+++ b/test/MapView.test.tsx
@@ -186,6 +186,7 @@ describe("MapView", () => {
 				routes={[
 					{
 						tripId: "TEST:T1",
+						routeId: "TEST:R1",
 						shapeId: "TEST:SH1",
 						fromStopId: "TEST:S1",
 						toStopId: "TEST:S3",
@@ -203,6 +204,7 @@ describe("MapView", () => {
 				routes={[
 					{
 						tripId: "TEST:T1",
+						routeId: "TEST:R1",
 						shapeId: "TEST:SH1",
 						fromStopId: "TEST:S1",
 						toStopId: "TEST:S3",
@@ -221,6 +223,7 @@ describe("MapView", () => {
 				routes={[
 					{
 						tripId: "TEST:T1",
+						routeId: "TEST:R1",
 						shapeId: "TEST:SH1",
 						fromStopId: "TEST:S1",
 						toStopId: "TEST:S3",
@@ -247,6 +250,7 @@ describe("MapView", () => {
 				routes={[
 					{
 						tripId: "TEST:T2",
+						routeId: "TEST:R2",
 						fromStopId: "TEST:S1",
 						toStopId: "TEST:S3",
 					},
@@ -264,6 +268,7 @@ describe("MapView", () => {
 				routes={[
 					{
 						tripId: "TEST:T1",
+						routeId: "TEST:R1",
 						shapeId: "TEST:SH1",
 						fromStopId: "TEST:S1",
 						toStopId: "TEST:S3",


### PR DESCRIPTION
## Summary

- 異なる路線（66 番と 77 番など）が同時にハイライトされる問題を修正
- 地図上でハイライト中の経路を最前面に描画
- クリックでハイライトを固定し、一覧表と地図を同期

## 変更内容

### ルートキーの修正
- `fromStopId-toStopId` → `routeId-fromStopId-toStopId` に変更
- DepartureBoard、MapView、App の全箇所で統一

### 地図の z-order 対応
- ハイライト用ポリラインを 2 パスで描画（非アクティブ → アクティブ）
- アクティブな経路が DOM 順で最前面に表示される

### クリックによるハイライト固定
- 一覧表の行または地図上の経路をクリックするとハイライトが固定される
- 固定中の行/経路を再クリックすると解除
- 別の行/経路をクリックすると固定対象が切り替わる
- 固定中も他の路線のホバーが独立して動作する
- `pinnedRouteKey` は App.tsx で一元管理し、一覧表と地図が常に同期

### テスト追加（6 件）
- ホバー時の `onRouteHover` コールバックのキー形式検証
- 異なる routeId の便が別キーを持つことの検証
- クリック時の `onRoutePinToggle` コールバック検証
- 固定/ホバー/優先度のスタイル検証

## Test plan

- [x] `npm run build` で型チェック通過
- [x] `npm run test` で全 289 テスト通過
- [ ] ブラウザで 66 番と 77 番が別々にハイライトされることを確認
- [ ] 地図上でハイライト中の経路が最前面に表示されることを確認
- [ ] クリック固定と解除が一覧表・地図で同期することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ルート固定機能を追加しました。ルートをクリックして固定し、同じルートを再度クリックして固定を解除できます。固定されたルートはホバー状態より優先的に表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->