### PR TITLE
fix: Leaflet Pane で経路の z-order を制御

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	MapContainer,
 	Marker,
+	Pane,
 	Polyline,
 	Popup,
 	TileLayer,
@@ -275,31 +276,21 @@ function MapView({
 					}}
 				/>
 			))}
-			{/* ハイライト区間（アクティブなものを最前面に表示するためにソート） */}
-			{[...highlightPolylines]
-				.sort((a, b) => {
-					// 0=非アクティブ, 1=固定, 2=ホバー（ホバーが最前面）
-					const priority = (pl: HighlightPolylineData) => {
-						if (hoveredKey === pl.key || hoveredRouteKey === pl.routeKey)
-							return 2;
-						if (pinnedRouteKey === pl.routeKey) return 1;
-						return 0;
-					};
-					return priority(a) - priority(b);
-				})
-				.map((pl) => {
-					const isActive =
-						hoveredKey === pl.key ||
-						hoveredRouteKey === pl.routeKey ||
-						pinnedRouteKey === pl.routeKey;
-					return (
+			{/* 非アクティブなハイライト区間 */}
+			<Pane name="highlight-inactive" style={{ zIndex: 450 }}>
+				{highlightPolylines
+					.filter(
+						(pl) =>
+							hoveredKey !== pl.key &&
+							hoveredRouteKey !== pl.routeKey &&
+							pinnedRouteKey !== pl.routeKey,
+					)
+					.map((pl) => (
 						<Polyline
 							key={`hl-${pl.key}`}
 							positions={pl.positions}
 							pathOptions={{
-								color: isActive
-									? ROUTE_COLOR_SECTION_HOVER
-									: ROUTE_COLOR_SECTION,
+								color: ROUTE_COLOR_SECTION,
 								weight: SECTION_WEIGHT,
 								opacity: 0.9,
 							}}
@@ -313,8 +304,66 @@ function MapView({
 								{pl.fromStopName} → {pl.toStopName}
 							</Tooltip>
 						</Polyline>
-					);
-				})}
+					))}
+			</Pane>
+			{/* 固定中のハイライト区間 */}
+			<Pane name="highlight-pinned" style={{ zIndex: 460 }}>
+				{highlightPolylines
+					.filter(
+						(pl) =>
+							pinnedRouteKey === pl.routeKey &&
+							hoveredKey !== pl.key &&
+							hoveredRouteKey !== pl.routeKey,
+					)
+					.map((pl) => (
+						<Polyline
+							key={`hl-${pl.key}`}
+							positions={pl.positions}
+							pathOptions={{
+								color: ROUTE_COLOR_SECTION_HOVER,
+								weight: SECTION_WEIGHT,
+								opacity: 0.9,
+							}}
+							eventHandlers={{
+								mouseover: () => handleMouseOver(pl.key),
+								mouseout: handleMouseOut,
+								click: () => handleClick(pl.key),
+							}}
+						>
+							<Tooltip sticky>
+								{pl.fromStopName} → {pl.toStopName}
+							</Tooltip>
+						</Polyline>
+					))}
+			</Pane>
+			{/* ホバー中のハイライト区間（最前面） */}
+			<Pane name="highlight-hovered" style={{ zIndex: 470 }}>
+				{highlightPolylines
+					.filter(
+						(pl) =>
+							hoveredKey === pl.key || hoveredRouteKey === pl.routeKey,
+					)
+					.map((pl) => (
+						<Polyline
+							key={`hl-${pl.key}`}
+							positions={pl.positions}
+							pathOptions={{
+								color: ROUTE_COLOR_SECTION_HOVER,
+								weight: SECTION_WEIGHT,
+								opacity: 0.9,
+							}}
+							eventHandlers={{
+								mouseover: () => handleMouseOver(pl.key),
+								mouseout: handleMouseOut,
+								click: () => handleClick(pl.key),
+							}}
+						>
+							<Tooltip sticky>
+								{pl.fromStopName} → {pl.toStopName}
+							</Tooltip>
+						</Polyline>
+					))}
+			</Pane>
 		</MapContainer>
 	);
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -35,9 +35,11 @@ const DEFAULT_ZOOM = 13;
 /** 全経路の色 */
 const ROUTE_COLOR_BASE = "#b0c4de";
 /** ハイライト区間の色 */
-const ROUTE_COLOR_SECTION = "#3B82F6";
+const ROUTE_COLOR_SECTION = "#B0C1E2";
+/** ハイライト区間の固定色 */
+const ROUTE_COLOR_SECTION_PINNED = "#6D8CC6";
 /** ハイライト区間のホバー色 */
-const ROUTE_COLOR_SECTION_HOVER = "#1D4ED8";
+const ROUTE_COLOR_SECTION_HOVER = "#375FA9";
 
 /** 全経路の線幅 */
 const BASE_WEIGHT = 6;
@@ -320,7 +322,7 @@ function MapView({
 							key={`hl-${pl.key}`}
 							positions={pl.positions}
 							pathOptions={{
-								color: ROUTE_COLOR_SECTION_HOVER,
+								color: ROUTE_COLOR_SECTION_PINNED,
 								weight: SECTION_WEIGHT,
 								opacity: 0.9,
 							}}

--- a/test/MapView.test.tsx
+++ b/test/MapView.test.tsx
@@ -279,7 +279,7 @@ describe("MapView", () => {
 		);
 		const polylines = screen.getAllByTestId("polyline");
 		expect(polylines[0].dataset.color).toBe("#b0c4de");
-		expect(polylines[1].dataset.color).toBe("#3B82F6");
+		expect(polylines[1].dataset.color).toBe("#B0C1E2");
 	});
 
 	it("ルートが空の場合でも地図は表示される", () => {

--- a/test/MapView.test.tsx
+++ b/test/MapView.test.tsx
@@ -29,6 +29,7 @@ vi.mock("leaflet/dist/images/marker-shadow.png", () => ({
 }));
 
 vi.mock("react-leaflet", () => ({
+	Pane: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 	MapContainer: ({
 		children,
 		...props


### PR DESCRIPTION
## Summary

- ハイライト中の経路が最前面に表示されない問題を修正
- Leaflet の Pane コンポーネントで 3 階層の z-index を制御

## 原因

React の配列ソートではレンダリング順は変わるが、Leaflet はレイヤーの DOM 順序を自身で管理するため、React-Leaflet の Polyline の描画順序は配列のソートでは変わらない。

## 修正内容

Pane コンポーネントで 3 階層に分離:
- `highlight-inactive` (z-index: 450): 非アクティブなハイライト区間
- `highlight-pinned` (z-index: 460): 固定中のハイライト区間
- `highlight-hovered` (z-index: 470): ホバー中のハイライト区間（最前面）

## Test plan

- [x] `npm run build` で型チェック通過
- [x] `npm run test` で全 291 テスト通過
- [ ] ブラウザでハイライト中の経路が最前面に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)