### PR TITLE
chore: upload-pages-artifact を v5 に更新し Node.js 24 対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: dist
 


### PR DESCRIPTION
## Summary

- `actions/upload-pages-artifact` を v4 → v5 に更新
- Node.js 20 の非推奨警告（2026 年 6 月 2 日期限）を解消

## 背景

デプロイワークフローで以下の警告が出ていた:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02.

`upload-pages-artifact` v5 は内部で `upload-artifact` v7（Node.js 24 対応）を使用する。

## Test plan

- [ ] マージ後にデプロイワークフローが正常に完了することを確認
- [ ] Node.js 20 の非推奨警告が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイメントパイプラインのアップデートを実施しました。GitHub Pages のビルドプロセスが改善され、より安定した配信が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->