### PR TITLE
feat: 一覧表のソート機能を追加

### DIFF
--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -105,22 +105,28 @@ export function DepartureBoard({
 		}
 	};
 
-	// 表示対象の便を統合しソート
+	// 表示対象の便を統合（ソートとは独立してメモ化）
+	const flattenedDepartures = useMemo(
+		() =>
+			visibleGroups.flatMap((group) =>
+				group.departures.map((dep) => ({
+					...dep,
+					toStopName: group.toStopName,
+					isNextDay: group.isNextDay,
+				})),
+			),
+		[visibleGroups],
+	);
+
+	// ソート適用
 	const allDepartures = useMemo(() => {
-		const deps = visibleGroups.flatMap((group) =>
-			group.departures.map((dep) => ({
-				...dep,
-				toStopName: group.toStopName,
-				isNextDay: group.isNextDay,
-			})),
-		);
 		const dir = sortDirection === "asc" ? 1 : -1;
-		return deps.sort((a, b) => {
-			const aVal = (sortKey === "leaveByTime" ? a.leaveByTime : a[sortKey]) ?? "";
-			const bVal = (sortKey === "leaveByTime" ? b.leaveByTime : b[sortKey]) ?? "";
+		return [...flattenedDepartures].sort((a, b) => {
+			const aVal = (a[sortKey] as string | undefined) ?? "";
+			const bVal = (b[sortKey] as string | undefined) ?? "";
 			return dir * aVal.localeCompare(bVal);
 		});
-	}, [visibleGroups, sortKey, sortDirection]);
+	}, [flattenedDepartures, sortKey, sortDirection]);
 
 	if (!hasRoutes) {
 		return (
@@ -202,30 +208,35 @@ export function DepartureBoard({
 						>
 							<table className="table table-sm">
 								<thead className="sticky top-0 z-10 bg-base-100">
+								{(() => {
+									const sortableHeader = (key: SortKey, label: string) => (
+										<th
+											className="cursor-pointer select-none"
+											tabIndex={0}
+											aria-sort={sortKey === key ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+											onClick={() => handleSortToggle(key)}
+											onKeyDown={(e) => {
+												if (e.key === "Enter" || e.key === " ") {
+													e.preventDefault();
+													handleSortToggle(key);
+												}
+											}}
+										>
+											{label}{sortKey === key && (sortDirection === "asc" ? " ▲" : " ▼")}
+										</th>
+									);
+									return (
 									<tr>
-										<th
-											className="cursor-pointer select-none"
-											onClick={() => handleSortToggle("leaveByTime")}
-										>
-											出発目安{sortKey === "leaveByTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
-										</th>
+										{sortableHeader("leaveByTime", "出発目安")}
 										<th>乗車</th>
-										<th
-											className="cursor-pointer select-none"
-											onClick={() => handleSortToggle("departureTime")}
-										>
-											発車{sortKey === "departureTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
-										</th>
-										<th
-											className="cursor-pointer select-none"
-											onClick={() => handleSortToggle("arrivalTime")}
-										>
-											到着{sortKey === "arrivalTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
-										</th>
+										{sortableHeader("departureTime", "発車")}
+										{sortableHeader("arrivalTime", "到着")}
 										<th>運賃</th>
 										<th>路線</th>
 										<th>行き先</th>
 									</tr>
+									);
+								})()}
 								</thead>
 								<tbody>
 									{allDepartures.map((dep) => {

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { DepartureGroup } from "../hooks/useDepartures";
 import { getAgencyColor } from "../lib/agency-colors";
 
@@ -53,6 +53,12 @@ function formatUpdatedTime(date: Date): string {
 /** スクロール領域の最大高さ（Tailwind の max-h-60 = 15rem 相当） */
 const SCROLL_MAX_HEIGHT_CLASS = "max-h-60";
 
+/** ソート可能なカラム */
+type SortKey = "leaveByTime" | "departureTime" | "arrivalTime";
+
+/** ソート方向 */
+type SortDirection = "asc" | "desc";
+
 /** 発車案内を降車バス停ごとにグルーピングして表示するコンポーネント */
 export function DepartureBoard({
 	groups,
@@ -87,18 +93,34 @@ export function DepartureBoard({
 		[groups, selectedDestination],
 	);
 
-	// 表示対象の便を統合し、発車時刻順にソート
+	const [sortKey, setSortKey] = useState<SortKey>("departureTime");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+	const handleSortToggle = (key: SortKey) => {
+		if (sortKey === key) {
+			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+		} else {
+			setSortKey(key);
+			setSortDirection("asc");
+		}
+	};
+
+	// 表示対象の便を統合しソート
 	const allDepartures = useMemo(() => {
-		return visibleGroups
-			.flatMap((group) =>
-				group.departures.map((dep) => ({
-					...dep,
-					toStopName: group.toStopName,
-					isNextDay: group.isNextDay,
-				})),
-			)
-			.sort((a, b) => a.departureTime.localeCompare(b.departureTime));
-	}, [visibleGroups]);
+		const deps = visibleGroups.flatMap((group) =>
+			group.departures.map((dep) => ({
+				...dep,
+				toStopName: group.toStopName,
+				isNextDay: group.isNextDay,
+			})),
+		);
+		const dir = sortDirection === "asc" ? 1 : -1;
+		return deps.sort((a, b) => {
+			const aVal = (sortKey === "leaveByTime" ? a.leaveByTime : a[sortKey]) ?? "";
+			const bVal = (sortKey === "leaveByTime" ? b.leaveByTime : b[sortKey]) ?? "";
+			return dir * aVal.localeCompare(bVal);
+		});
+	}, [visibleGroups, sortKey, sortDirection]);
 
 	if (!hasRoutes) {
 		return (
@@ -181,10 +203,25 @@ export function DepartureBoard({
 							<table className="table table-sm">
 								<thead className="sticky top-0 z-10 bg-base-100">
 									<tr>
-										<th>出発目安</th>
+										<th
+											className="cursor-pointer select-none"
+											onClick={() => handleSortToggle("leaveByTime")}
+										>
+											出発目安{sortKey === "leaveByTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
+										</th>
 										<th>乗車</th>
-										<th>発車</th>
-										<th>到着</th>
+										<th
+											className="cursor-pointer select-none"
+											onClick={() => handleSortToggle("departureTime")}
+										>
+											発車{sortKey === "departureTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
+										</th>
+										<th
+											className="cursor-pointer select-none"
+											onClick={() => handleSortToggle("arrivalTime")}
+										>
+											到着{sortKey === "arrivalTime" && (sortDirection === "asc" ? " ▲" : " ▼")}
+										</th>
 										<th>運賃</th>
 										<th>路線</th>
 										<th>行き先</th>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -155,6 +155,30 @@ export function DepartureBoard({
 	const allNextDay =
 		visibleGroups.length > 0 && visibleGroups.every((g) => g.isNextDay);
 
+	const sortableHeader = (key: SortKey, label: string) => (
+		<th
+			className="cursor-pointer select-none"
+			tabIndex={0}
+			aria-sort={
+				sortKey === key
+					? sortDirection === "asc"
+						? "ascending"
+						: "descending"
+					: "none"
+			}
+			onClick={() => handleSortToggle(key)}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					handleSortToggle(key);
+				}
+			}}
+		>
+			{label}
+			{sortKey === key && (sortDirection === "asc" ? " ▲" : " ▼")}
+		</th>
+	);
+
 	return (
 		<div className="space-y-4">
 			{lastUpdated && (
@@ -208,24 +232,6 @@ export function DepartureBoard({
 						>
 							<table className="table table-sm">
 								<thead className="sticky top-0 z-10 bg-base-100">
-								{(() => {
-									const sortableHeader = (key: SortKey, label: string) => (
-										<th
-											className="cursor-pointer select-none"
-											tabIndex={0}
-											aria-sort={sortKey === key ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
-											onClick={() => handleSortToggle(key)}
-											onKeyDown={(e) => {
-												if (e.key === "Enter" || e.key === " ") {
-													e.preventDefault();
-													handleSortToggle(key);
-												}
-											}}
-										>
-											{label}{sortKey === key && (sortDirection === "asc" ? " ▲" : " ▼")}
-										</th>
-									);
-									return (
 									<tr>
 										{sortableHeader("leaveByTime", "出発目安")}
 										<th>乗車</th>
@@ -235,8 +241,6 @@ export function DepartureBoard({
 										<th>路線</th>
 										<th>行き先</th>
 									</tr>
-									);
-								})()}
 								</thead>
 								<tbody>
 									{allDepartures.map((dep) => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -686,7 +686,7 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(rows[1].className).not.toContain("bg-info/10");
 	});
 
-	it("発車ヘッダークリックでソート方向が切り替わる", () => {
+	it("発車ヘッダークリックでソート方向が切り替わり行順序が反転する", () => {
 		render(
 			<DepartureBoard
 				groups={[makeGroup()]}
@@ -699,9 +699,20 @@ describe("DepartureBoard コンポーネント", () => {
 		const departureHeader = headers[2]; // 出発目安, 乗車, 発車
 		// 初期状態: 昇順
 		expect(departureHeader.textContent).toContain("▲");
+		const tbody = screen.getAllByRole("rowgroup")[1];
+		const rowsBefore = within(tbody).getAllByRole("row");
+		const timesBefore = rowsBefore.map(
+			(row) => within(row).getAllByRole("cell")[2].textContent,
+		);
+		expect(timesBefore).toEqual(["08:00", "09:00"]);
 		// クリックで降順に
 		fireEvent.click(departureHeader);
 		expect(departureHeader.textContent).toContain("▼");
+		const rowsAfter = within(tbody).getAllByRole("row");
+		const timesAfter = rowsAfter.map(
+			(row) => within(row).getAllByRole("cell")[2].textContent,
+		);
+		expect(timesAfter).toEqual(["09:00", "08:00"]);
 	});
 
 	it("出発目安ヘッダークリックでソートキーが切り替わる", () => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -250,13 +250,17 @@ describe("DepartureBoard コンポーネント", () => {
 				hasRoutes={true}
 			/>,
 		);
-		expect(screen.getByText("出発目安")).toBeInTheDocument();
-		expect(screen.getByText("乗車")).toBeInTheDocument();
-		expect(screen.getByText("発車")).toBeInTheDocument();
-		expect(screen.getByText("到着")).toBeInTheDocument();
-		expect(screen.getByText("運賃")).toBeInTheDocument();
-		expect(screen.getByText("路線")).toBeInTheDocument();
-		expect(screen.getByText("行き先")).toBeInTheDocument();
+		const headers = screen.getAllByRole("columnheader");
+		const headerTexts = headers.map((h) => h.textContent?.replace(/ [▲▼]/, ""));
+		expect(headerTexts).toEqual([
+			"出発目安",
+			"乗車",
+			"発車",
+			"到着",
+			"運賃",
+			"路線",
+			"行き先",
+		]);
 	});
 
 	it("エラー発生時はエラーメッセージを表示する", () => {
@@ -680,6 +684,45 @@ describe("DepartureBoard コンポーネント", () => {
 		const rows = screen.getAllByRole("row");
 		expect(rows[1].className).toContain("bg-info/20");
 		expect(rows[1].className).not.toContain("bg-info/10");
+	});
+
+	it("発車ヘッダークリックでソート方向が切り替わる", () => {
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+		const headers = screen.getAllByRole("columnheader");
+		const departureHeader = headers[2]; // 出発目安, 乗車, 発車
+		// 初期状態: 昇順
+		expect(departureHeader.textContent).toContain("▲");
+		// クリックで降順に
+		fireEvent.click(departureHeader);
+		expect(departureHeader.textContent).toContain("▼");
+	});
+
+	it("出発目安ヘッダークリックでソートキーが切り替わる", () => {
+		render(
+			<DepartureBoard
+				groups={[makeGroup()]}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+		const headers = screen.getAllByRole("columnheader");
+		const leaveByHeader = headers[0]; // 出発目安
+		const departureHeader = headers[2]; // 発車
+		// 初期状態: 発車に▲
+		expect(departureHeader.textContent).toContain("▲");
+		expect(leaveByHeader.textContent).not.toContain("▲");
+		// 出発目安をクリック
+		fireEvent.click(leaveByHeader);
+		expect(leaveByHeader.textContent).toContain("▲");
+		expect(departureHeader.textContent).not.toContain("▲");
 	});
 
 	it("Asaca 乗り継ぎ割引の注釈が表示される", () => {


### PR DESCRIPTION
## Summary

- 出発目安・発車・到着の各ヘッダーをクリックしてソート順を変更できる機能を追加
- ソートインジケーター（▲昇順 / ▼降順）をヘッダーに表示

## 操作方法

- ヘッダーをクリックすると、そのカラムで昇順ソートされる
- 同じヘッダーを再度クリックすると降順に切り替わる
- 別のヘッダーをクリックするとソートキーが切り替わり昇順にリセットされる
- デフォルトは発車時刻の昇順

## Test plan

- [x] `npm run build` で型チェック通過
- [x] `npm run test` で全 293 テスト通過
- [ ] ブラウザで各ヘッダークリックによるソート切り替えを確認
- [ ] ソートインジケーター（▲/▼）が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 出発ボードにインタラクティブな並び替え機能を追加しました。列ヘッダー（出発予定時刻、発車時刻、到着時刻）をクリックしてソート順序を変更できます。▲/▼インジケータでソート方向を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->