### PR TITLE
feat: 名前に包含関係があるバス停を統合して取り扱い

### DIFF
--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -4,23 +4,13 @@ import { NEARBY_THRESHOLD_METERS, distanceMeters } from "./geo-utils";
 /** 名前統合の距離閾値（メートル） */
 const MERGE_THRESHOLD_METERS = 200;
 
-/** バス停名を正規化する（全角数字/英字→半角、全角スペース→半角） */
+/** バス停名を正規化する（Unicode NFKC 正規化で全角/半角を統一） */
 function normalizeName(name: string): string {
-	return name
-		.replace(/[０-９]/g, (c) =>
-			String.fromCharCode(c.charCodeAt(0) - 0xfee0),
-		)
-		.replace(/[Ａ-Ｚａ-ｚ]/g, (c) =>
-			String.fromCharCode(c.charCodeAt(0) - 0xfee0),
-		)
-		.replace(/\u3000/g, " ")
-		.trim();
+	return name.normalize("NFKC").trim();
 }
 
-/** 正規化後に一方が他方を含む（前方/後方/部分一致/正規化一致）か判定する */
-function namesContain(a: string, b: string): boolean {
-	const na = normalizeName(a);
-	const nb = normalizeName(b);
+/** 正規化済みの名前で包含関係を判定する */
+function normalizedNamesContain(na: string, nb: string): boolean {
 	return na.includes(nb) || nb.includes(na);
 }
 
@@ -177,11 +167,17 @@ function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
 	// 比較には元の名前を使い、統合後の表示名は最後に構築する
 	const originalNames = clusters.map((c) => c.stopName);
 	const mergedNames: string[][] = clusters.map((_, i) => [originalNames[i]]);
+	// 正規化済み名前を事前計算してループ内の再正規化を回避
+	const normalizedMergedNames: string[][] = mergedNames.map((names) =>
+		names.map(normalizeName),
+	);
 	for (let i = 0; i < clusters.length; i++) {
 		for (let j = i + 1; j < clusters.length; j++) {
 			const canMerge =
-				mergedNames[i].some((ni) =>
-					mergedNames[j].some((nj) => namesContain(ni, nj)),
+				normalizedMergedNames[i].some((ni) =>
+					normalizedMergedNames[j].some((nj) =>
+						normalizedNamesContain(ni, nj),
+					),
 				) &&
 				distanceMeters(
 					clusters[i].lat,
@@ -192,8 +188,10 @@ function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
 			if (canMerge) {
 				clusters[i].stopIds.push(...clusters[j].stopIds);
 				mergedNames[i].push(...mergedNames[j]);
+				normalizedMergedNames[i].push(...normalizedMergedNames[j]);
 				clusters.splice(j, 1);
 				mergedNames.splice(j, 1);
+				normalizedMergedNames.splice(j, 1);
 				j--;
 			}
 		}
@@ -318,6 +316,7 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 
 	// 名前に包含関係があるバス停（200m 以内、bounding box で候補を絞り込み）
 	const siblingIds = new Set(siblings);
+	const normalizedRefName = normalizeName(refName);
 	const degPerMeter = 1 / 111_000; // 緯度 1 度 ≈ 111km
 	const latDelta = MERGE_THRESHOLD_METERS * degPerMeter;
 	const lonDelta =
@@ -342,7 +341,7 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 			};
 			if (siblingIds.has(row.stop_id)) continue;
 			if (
-				namesContain(refName, row.stop_name) &&
+				normalizedNamesContain(normalizedRefName, normalizeName(row.stop_name)) &&
 				distanceMeters(refLat, refLon, row.stop_lat, row.stop_lon) <=
 					MERGE_THRESHOLD_METERS
 			) {

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -1,6 +1,30 @@
 import type { Database } from "sql.js";
 import { NEARBY_THRESHOLD_METERS, distanceMeters } from "./geo-utils";
 
+/** 名前統合の距離閾値（メートル） */
+const MERGE_THRESHOLD_METERS = 200;
+
+/** バス停名を正規化する（全角数字/英字→半角、全角スペース→半角） */
+function normalizeName(name: string): string {
+	return name
+		.replace(/[０-９]/g, (c) =>
+			String.fromCharCode(c.charCodeAt(0) - 0xfee0),
+		)
+		.replace(/[Ａ-Ｚａ-ｚ]/g, (c) =>
+			String.fromCharCode(c.charCodeAt(0) - 0xfee0),
+		)
+		.replace(/\u3000/g, " ")
+		.trim();
+}
+
+/** 正規化後に一方が他方を含む（前方/後方/部分一致）か判定する */
+function namesContain(a: string, b: string): boolean {
+	const na = normalizeName(a);
+	const nb = normalizeName(b);
+	if (na === nb) return false;
+	return na.includes(nb) || nb.includes(na);
+}
+
 /** バス停検索結果の型 */
 export type StopSearchResult = {
 	stop_id: string;
@@ -96,12 +120,15 @@ export function searchStops(
 }
 
 /**
- * 同名バス停を距離ベースでクラスタリングする。
+ * バス停を距離ベースでクラスタリングする。
  *
  * 同じ名前のバス停を近距離（500m 以内）でグループ化する。
+ * さらに、名前に包含関係があり 200m 以内のクラスタを統合する。
+ * 統合されたクラスタの表示名は「短い名前/長い名前」形式になる。
  * 入力は stop_id 昇順であるため、最初にクラスタを形成した stop_id が代表となる。
  */
 function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
+	// 同名バス停を距離でクラスタリング
 	const byName = new Map<string, RawStopRow[]>();
 	for (const row of rows) {
 		const existing = byName.get(row.stop_name);
@@ -145,6 +172,31 @@ function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
 		}
 
 		clusters.push(...nameClusters);
+	}
+
+	// 名前に包含関係があり 200m 以内のクラスタを統合
+	for (let i = 0; i < clusters.length; i++) {
+		for (let j = i + 1; j < clusters.length; j++) {
+			if (
+				namesContain(clusters[i].stopName, clusters[j].stopName) &&
+				distanceMeters(
+					clusters[i].lat,
+					clusters[i].lon,
+					clusters[j].lat,
+					clusters[j].lon,
+				) <= MERGE_THRESHOLD_METERS
+			) {
+				// 短い名前/長い名前 の形式で統合
+				const nameA = clusters[i].stopName;
+				const nameB = clusters[j].stopName;
+				const shorter = nameA.length <= nameB.length ? nameA : nameB;
+				const longer = nameA.length <= nameB.length ? nameB : nameA;
+				clusters[i].stopName = `${shorter}/${longer}`;
+				clusters[i].stopIds.push(...clusters[j].stopIds);
+				clusters.splice(j, 1);
+				j--;
+			}
+		}
 	}
 
 	clusters.sort((a, b) => {
@@ -211,6 +263,7 @@ export function getStopName(db: Database, stopId: string): string {
 
 /**
  * 指定した stop_id と同名かつ近距離（500m 以内）のバス停の全 stop_id を返す。
+ * さらに、名前に包含関係があり 200m 以内のバス停も兄弟として返す。
  * 同じ物理的な場所にある上り・下りや別事業者のバス停を網羅する。
  * 遠距離の同名バス停は含めない。
  */
@@ -231,6 +284,7 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 
 	const { stop_name: refName, stop_lat: refLat, stop_lon: refLon } = refStop;
 
+	// 同名バス停（500m 以内）
 	const siblingsStmt = db.prepare(
 		"SELECT stop_id, stop_lat, stop_lon FROM stops WHERE stop_name = ?",
 	);
@@ -252,6 +306,33 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 		}
 	} finally {
 		siblingsStmt.free();
+	}
+
+	// 名前に包含関係があるバス停（200m 以内）
+	const siblingIds = new Set(siblings);
+	const allStopsStmt = db.prepare(
+		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops",
+	);
+	try {
+		while (allStopsStmt.step()) {
+			const row = allStopsStmt.getAsObject() as {
+				stop_id: string;
+				stop_name: string;
+				stop_lat: number;
+				stop_lon: number;
+			};
+			if (siblingIds.has(row.stop_id)) continue;
+			if (
+				namesContain(refName, row.stop_name) &&
+				distanceMeters(refLat, refLon, row.stop_lat, row.stop_lon) <=
+					MERGE_THRESHOLD_METERS
+			) {
+				siblings.push(row.stop_id);
+				siblingIds.add(row.stop_id);
+			}
+		}
+	} finally {
+		allStopsStmt.free();
 	}
 
 	return siblings.length > 0 ? siblings : [stopId];

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -17,11 +17,10 @@ function normalizeName(name: string): string {
 		.trim();
 }
 
-/** 正規化後に一方が他方を含む（前方/後方/部分一致）か判定する */
+/** 正規化後に一方が他方を含む（前方/後方/部分一致/正規化一致）か判定する */
 function namesContain(a: string, b: string): boolean {
 	const na = normalizeName(a);
 	const nb = normalizeName(b);
-	if (na === nb) return false;
 	return na.includes(nb) || nb.includes(na);
 }
 
@@ -175,27 +174,36 @@ function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
 	}
 
 	// 名前に包含関係があり 200m 以内のクラスタを統合
+	// 比較には元の名前を使い、統合後の表示名は最後に構築する
+	const originalNames = clusters.map((c) => c.stopName);
+	const mergedNames: string[][] = clusters.map((_, i) => [originalNames[i]]);
 	for (let i = 0; i < clusters.length; i++) {
 		for (let j = i + 1; j < clusters.length; j++) {
-			if (
-				namesContain(clusters[i].stopName, clusters[j].stopName) &&
+			const canMerge =
+				mergedNames[i].some((ni) =>
+					mergedNames[j].some((nj) => namesContain(ni, nj)),
+				) &&
 				distanceMeters(
 					clusters[i].lat,
 					clusters[i].lon,
 					clusters[j].lat,
 					clusters[j].lon,
-				) <= MERGE_THRESHOLD_METERS
-			) {
-				// 短い名前/長い名前 の形式で統合
-				const nameA = clusters[i].stopName;
-				const nameB = clusters[j].stopName;
-				const shorter = nameA.length <= nameB.length ? nameA : nameB;
-				const longer = nameA.length <= nameB.length ? nameB : nameA;
-				clusters[i].stopName = `${shorter}/${longer}`;
+				) <= MERGE_THRESHOLD_METERS;
+			if (canMerge) {
 				clusters[i].stopIds.push(...clusters[j].stopIds);
+				mergedNames[i].push(...mergedNames[j]);
 				clusters.splice(j, 1);
+				mergedNames.splice(j, 1);
 				j--;
 			}
+		}
+	}
+	// 統合された名前を「短い名前/長い名前」形式に設定
+	for (let i = 0; i < clusters.length; i++) {
+		const uniqueNames = [...new Set(mergedNames[i])];
+		if (uniqueNames.length > 1) {
+			uniqueNames.sort((a, b) => a.length - b.length);
+			clusters[i].stopName = uniqueNames.join("/");
 		}
 	}
 
@@ -308,14 +316,25 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 		siblingsStmt.free();
 	}
 
-	// 名前に包含関係があるバス停（200m 以内）
+	// 名前に包含関係があるバス停（200m 以内、bounding box で候補を絞り込み）
 	const siblingIds = new Set(siblings);
-	const allStopsStmt = db.prepare(
-		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops",
+	const degPerMeter = 1 / 111_000; // 緯度 1 度 ≈ 111km
+	const latDelta = MERGE_THRESHOLD_METERS * degPerMeter;
+	const lonDelta =
+		MERGE_THRESHOLD_METERS /
+		(111_000 * Math.cos((refLat * Math.PI) / 180));
+	const nearbyStmt = db.prepare(
+		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE stop_lat BETWEEN ? AND ? AND stop_lon BETWEEN ? AND ?",
 	);
 	try {
-		while (allStopsStmt.step()) {
-			const row = allStopsStmt.getAsObject() as {
+		nearbyStmt.bind([
+			refLat - latDelta,
+			refLat + latDelta,
+			refLon - lonDelta,
+			refLon + lonDelta,
+		]);
+		while (nearbyStmt.step()) {
+			const row = nearbyStmt.getAsObject() as {
 				stop_id: string;
 				stop_name: string;
 				stop_lat: number;
@@ -332,7 +351,7 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 			}
 		}
 	} finally {
-		allStopsStmt.free();
+		nearbyStmt.free();
 	}
 
 	return siblings.length > 0 ? siblings : [stopId];


### PR DESCRIPTION
## Summary

- 名前に包含関係（前方/後方/部分一致）があり 200m 以内のバス停を統合
- 検索結果で「旭川駅/旭川駅前」のように統合表示
- 発車案内で統合されたバス停の全便を表示

## 統合ルール

正規化（全角→半角）後に一方の名前が他方に含まれ、かつ最短距離が 200m 以内の場合に統合する。

## 統合される 20 ペア

| 距離 | バス停ペア |
|------|----------|
| 0m | 神楽３条４丁目 / 神楽3条 |
| 0m | 護国神社 / 護国神社前 |
| 0m | 旭川医大前 / 旭川医大 |
| 1m | 旭川駅 / 旭川駅前 |
| 4m | 医大病院前 / 旭川医大病院前 |
| その他 15 ペア |

## Test plan

- [x] `npm run build` で型チェック通過
- [x] `npm run test` で全 293 テスト通過
- [x] ブラウザで「旭川駅」検索時に「旭川駅/旭川駅前」として統合表示されることを確認
- [ ] 統合バス停を選択して登録すると、両方のバス停の便が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 停止地点検索の精度と名前マッチング機能が向上しました
  * 類似した名前を持つ停止地点をより正確に統合するようになりました
  * 周辺エリアの関連停止地点を検出する機能を強化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->