### PR TITLE
feat: ソート列のハイライトとテーマ切り替え機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { RouteTransfer } from "./components/RouteTransfer";
 import { useDatabase } from "./hooks/useDatabase";
 import { useDepartures } from "./hooks/useDepartures";
 import { useRoutes } from "./hooks/useRoutes";
+import { type ThemePreference, useTheme } from "./hooks/useTheme";
 import { getDataExpiry } from "./lib/data-expiry";
 
 /** 現在日付を YYYYMMDD 形式で返す（ローカル） */
@@ -83,13 +84,27 @@ function App() {
 		return result;
 	}, [groups, effectiveDestination]);
 
+	const { preference, changeTheme } = useTheme();
+
 	return (
 		<div className="min-h-screen bg-base-200">
 			<header className="navbar bg-base-100">
 				<div className="flex-1">
 					<h1 className="text-xl font-bold">旭川バス発車案内</h1>
 				</div>
-				<div className="flex-none">
+				<div className="flex-none gap-2">
+					<select
+						aria-label="テーマ切り替え"
+						className="select select-sm select-bordered"
+						value={preference}
+						onChange={(e) =>
+							changeTheme(e.target.value as ThemePreference)
+						}
+					>
+						<option value="system">デバイス設定</option>
+						<option value="light">ライト</option>
+						<option value="dark">ダーク</option>
+					</select>
 					<RouteTransfer onImportComplete={reload} />
 				</div>
 			</header>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -155,9 +155,16 @@ export function DepartureBoard({
 	const allNextDay =
 		visibleGroups.length > 0 && visibleGroups.every((g) => g.isNextDay);
 
+	/** ソートキーから td のインデックスへのマッピング */
+	const sortColumnIndex: Record<SortKey, number> = {
+		leaveByTime: 0,
+		departureTime: 2,
+		arrivalTime: 3,
+	};
+
 	const sortableHeader = (key: SortKey, label: string) => (
 		<th
-			className="cursor-pointer select-none"
+			className={`cursor-pointer select-none ${sortKey === key ? "bg-base-200" : ""}`}
 			tabIndex={0}
 			aria-sort={
 				sortKey === key
@@ -265,7 +272,7 @@ export function DepartureBoard({
 													}
 												}}
 											>
-												<td className="font-mono">
+												<td className={`font-mono ${sortColumnIndex[sortKey] === 0 ? "bg-base-200/50" : ""}`}>
 													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
 													{dep.isDeparted && (
 														<span className="ml-1 badge badge-sm badge-ghost">
@@ -274,10 +281,10 @@ export function DepartureBoard({
 													)}
 												</td>
 												<td>{dep.fromStopName ?? "-"}</td>
-												<td className="font-mono">
+												<td className={`font-mono ${sortColumnIndex[sortKey] === 2 ? "bg-base-200/50" : ""}`}>
 													{formatTime(dep.departureTime)}
 												</td>
-												<td className="font-mono">
+												<td className={`font-mono ${sortColumnIndex[sortKey] === 3 ? "bg-base-200/50" : ""}`}>
 													{formatTime(dep.arrivalTime)}
 												</td>
 												<td>

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -155,16 +155,9 @@ export function DepartureBoard({
 	const allNextDay =
 		visibleGroups.length > 0 && visibleGroups.every((g) => g.isNextDay);
 
-	/** ソートキーから td のインデックスへのマッピング */
-	const sortColumnIndex: Record<SortKey, number> = {
-		leaveByTime: 0,
-		departureTime: 2,
-		arrivalTime: 3,
-	};
-
 	const sortableHeader = (key: SortKey, label: string) => (
 		<th
-			className={`cursor-pointer select-none ${sortKey === key ? "bg-base-200" : ""}`}
+			className={`cursor-pointer select-none ${sortKey === key ? "bg-base-300" : ""}`}
 			tabIndex={0}
 			aria-sort={
 				sortKey === key
@@ -272,7 +265,7 @@ export function DepartureBoard({
 													}
 												}}
 											>
-												<td className={`font-mono ${sortColumnIndex[sortKey] === 0 ? "bg-base-200/50" : ""}`}>
+												<td className={`font-mono ${sortKey === "leaveByTime" ? "bg-base-300/50" : ""}`}>
 													{dep.leaveByTime ? formatTime(dep.leaveByTime) : "-"}
 													{dep.isDeparted && (
 														<span className="ml-1 badge badge-sm badge-ghost">
@@ -281,10 +274,10 @@ export function DepartureBoard({
 													)}
 												</td>
 												<td>{dep.fromStopName ?? "-"}</td>
-												<td className={`font-mono ${sortColumnIndex[sortKey] === 2 ? "bg-base-200/50" : ""}`}>
+												<td className={`font-mono ${sortKey === "departureTime" ? "bg-base-300/50" : ""}`}>
 													{formatTime(dep.departureTime)}
 												</td>
-												<td className={`font-mono ${sortColumnIndex[sortKey] === 3 ? "bg-base-200/50" : ""}`}>
+												<td className={`font-mono ${sortKey === "arrivalTime" ? "bg-base-300/50" : ""}`}>
 													{formatTime(dep.arrivalTime)}
 												</td>
 												<td>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -38,7 +38,6 @@ export function useTheme() {
 	const changeTheme = useCallback((newPref: ThemePreference) => {
 		setPreference(newPref);
 		localStorage.setItem(STORAGE_KEY, newPref);
-		applyTheme(newPref);
 	}, []);
 
 	// 初回マウント時にテーマを適用
@@ -46,14 +45,12 @@ export function useTheme() {
 		applyTheme(preference);
 	}, [preference]);
 
-	// デバイスのカラースキーム変更を監視（system モード時に追従）
+	// デバイスのカラースキーム変更を監視（system モード時のみ）
 	useEffect(() => {
+		if (preference !== "system") return;
+
 		const mql = window.matchMedia("(prefers-color-scheme: dark)");
-		const handler = () => {
-			if (preference === "system") {
-				applyTheme("system");
-			}
-		};
+		const handler = () => applyTheme("system");
 		mql.addEventListener("change", handler);
 		return () => mql.removeEventListener("change", handler);
 	}, [preference]);

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+
+/** テーマの設定値 */
+export type ThemePreference = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme-preference";
+
+/** デバイスのカラースキーム設定を取得する */
+function getSystemTheme(): "light" | "dark" {
+	return window.matchMedia("(prefers-color-scheme: dark)").matches
+		? "dark"
+		: "light";
+}
+
+/** localStorage からテーマ設定を読み込む */
+function loadPreference(): ThemePreference {
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored === "light" || stored === "dark" || stored === "system") {
+		return stored;
+	}
+	return "system";
+}
+
+/** テーマ設定に基づいて実際のテーマを適用する */
+function applyTheme(preference: ThemePreference): void {
+	const theme = preference === "system" ? getSystemTheme() : preference;
+	document.documentElement.setAttribute("data-theme", theme);
+}
+
+/**
+ * テーマ設定を管理するフック。
+ *
+ * localStorage に設定を保存し、デバイスのカラースキーム変更にも追従する。
+ */
+export function useTheme() {
+	const [preference, setPreference] = useState<ThemePreference>(loadPreference);
+
+	const changeTheme = useCallback((newPref: ThemePreference) => {
+		setPreference(newPref);
+		localStorage.setItem(STORAGE_KEY, newPref);
+		applyTheme(newPref);
+	}, []);
+
+	// 初回マウント時にテーマを適用
+	useEffect(() => {
+		applyTheme(preference);
+	}, [preference]);
+
+	// デバイスのカラースキーム変更を監視（system モード時に追従）
+	useEffect(() => {
+		const mql = window.matchMedia("(prefers-color-scheme: dark)");
+		const handler = () => {
+			if (preference === "system") {
+				applyTheme("system");
+			}
+		};
+		mql.addEventListener("change", handler);
+		return () => mql.removeEventListener("change", handler);
+	}, [preference]);
+
+	return { preference, changeTheme } as const;
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -7,6 +7,7 @@ const STORAGE_KEY = "theme-preference";
 
 /** デバイスのカラースキーム設定を取得する */
 function getSystemTheme(): "light" | "dark" {
+	if (typeof window.matchMedia !== "function") return "light";
 	return window.matchMedia("(prefers-color-scheme: dark)").matches
 		? "dark"
 		: "light";
@@ -48,6 +49,7 @@ export function useTheme() {
 	// デバイスのカラースキーム変更を監視（system モード時のみ）
 	useEffect(() => {
 		if (preference !== "system") return;
+		if (typeof window.matchMedia !== "function") return;
 
 		const mql = window.matchMedia("(prefers-color-scheme: dark)");
 		const handler = () => applyTheme("system");

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,1 +1,16 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom に window.matchMedia が存在しないためモックを追加
+Object.defineProperty(window, "matchMedia", {
+	writable: true,
+	value: (query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: () => {},
+		removeListener: () => {},
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => false,
+	}),
+});


### PR DESCRIPTION
## Summary

- ソート中の列をハイライト表示
- ライト/ダーク/デバイス設定の 3 値でテーマを切り替え可能に

## 変更内容

### ソート列のハイライト
- ソート中の列ヘッダーに `bg-base-200` を適用
- 対応するデータセルに `bg-base-200/50` を適用
- ソート列の切り替えで即座にハイライトが移動

### テーマ切り替え
- ヘッダーにテーマ選択プルダウンを配置
- 「デバイス設定」「ライト」「ダーク」の 3 値
- 初期値は「デバイス設定」
- 設定は localStorage に保存し、再訪問時に復元
- デバイスのカラースキーム変更（OS 設定変更）にも追従
- DaisyUI の `data-theme` 属性で切り替え

## Test plan

- [x] `npm run build` で型チェック通過
- [x] `npm run test` で全 293 テスト通過
- [ ] ブラウザでソート列のハイライトを確認
- [ ] テーマ切り替えでライト/ダーク/デバイス設定が反映されることを確認
- [ ] ブラウザを閉じて再度開いた際にテーマ設定が復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプリ内にテーマ選択を追加（ライト／ダーク／システム連動）。選択は保存され、システム設定の変化にも追従します。

* **改善**
  * 発車ボードのテーブルで、現在の並び替え列を視覚的に強調表示するようにしました。

* **テスト**
  * 実行環境での配色検出を安定させるためのテストセットアップを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->