### PR TITLE
feat: レイアウト入れ替えと行先フィルタの全行先対応

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,18 +120,6 @@ function App() {
 				{db && !loading && !error && (
 					<>
 						<ExpiryWarning expiry={expiry} currentDate={currentDate} />
-						<DepartureBoard
-							groups={groups}
-							lastUpdated={lastUpdated}
-							error={departuresError}
-							hasRoutes={routes.length > 0}
-							hoveredRouteKey={hoveredRouteKey}
-							onRouteHover={handleRouteHover}
-							pinnedRouteKey={pinnedRouteKey}
-							onRoutePinToggle={handleRoutePinToggle}
-							selectedDestination={effectiveDestination}
-							onDestinationChange={setSelectedDestination}
-						/>
 						{mapRoutes.length > 0 && (
 							<div className="card bg-base-100 shadow-sm">
 								<div className="card-body">
@@ -147,6 +135,18 @@ function App() {
 								</div>
 							</div>
 						)}
+						<DepartureBoard
+							groups={groups}
+							lastUpdated={lastUpdated}
+							error={departuresError}
+							hasRoutes={routes.length > 0}
+							hoveredRouteKey={hoveredRouteKey}
+							onRouteHover={handleRouteHover}
+							pinnedRouteKey={pinnedRouteKey}
+							onRoutePinToggle={handleRoutePinToggle}
+							selectedDestination={effectiveDestination}
+							onDestinationChange={setSelectedDestination}
+						/>
 						<RouteRegistration
 							db={db}
 							routes={routes}

--- a/src/hooks/useDepartures.ts
+++ b/src/hooks/useDepartures.ts
@@ -172,14 +172,9 @@ export function useDepartures(
 			// 登録経路のうち、グループが存在しないか全便出発済みのものがある場合
 			const needsNextDay = currentRoutes.some((route) => {
 				const group = groupMap.get(route.toStopId);
-				return (
-					!group ||
-					(!group.isNextDay &&
-						group.departures.length > 0 &&
-						group.departures.every((d) => d.isDeparted))
-				);
+				return !group || group.departures.every((d) => d.isDeparted);
 			});
-			if (needsNextDay && currentRoutes.length > 0) {
+			if (needsNextDay) {
 				const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 				const tomorrowServiceIds = getActiveServiceIds(currentDb, tomorrow);
 
@@ -189,7 +184,7 @@ export function useDepartures(
 						const existingGroup = groupMap.get(route.toStopId);
 						if (
 							existingGroup &&
-							existingGroup.departures.some((d) => d.isDeparted === false)
+							existingGroup.departures.some((d) => !d.isDeparted)
 						) {
 							continue;
 						}

--- a/src/hooks/useDepartures.ts
+++ b/src/hooks/useDepartures.ts
@@ -169,26 +169,27 @@ export function useDepartures(
 			}
 
 			// 翌日の始発便を取得
-			// 全行先が空の場合、または特定行先の全便が出発済みの場合
-			const needsNextDay =
-				groupMap.size === 0 ||
-				[...groupMap.values()].some(
-					(g) =>
-						!g.isNextDay &&
-						g.departures.length > 0 &&
-						g.departures.every((d) => d.isDeparted),
+			// 登録経路のうち、グループが存在しないか全便出発済みのものがある場合
+			const needsNextDay = currentRoutes.some((route) => {
+				const group = groupMap.get(route.toStopId);
+				return (
+					!group ||
+					(!group.isNextDay &&
+						group.departures.length > 0 &&
+						group.departures.every((d) => d.isDeparted))
 				);
+			});
 			if (needsNextDay && currentRoutes.length > 0) {
 				const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 				const tomorrowServiceIds = getActiveServiceIds(currentDb, tomorrow);
 
 				if (tomorrowServiceIds.length > 0) {
 					for (const route of currentRoutes) {
-						// 既にグループがあり、全便出発済みでなければスキップ
+						// 既にグループがあり、未出発の便が残っていればスキップ
 						const existingGroup = groupMap.get(route.toStopId);
 						if (
 							existingGroup &&
-							!existingGroup.departures.every((d) => d.isDeparted)
+							existingGroup.departures.some((d) => d.isDeparted === false)
 						) {
 							continue;
 						}

--- a/src/hooks/useDepartures.ts
+++ b/src/hooks/useDepartures.ts
@@ -168,13 +168,31 @@ export function useDepartures(
 				}
 			}
 
-			// 翌日の始発便を取得（本日分が全て空の場合）
-			if (groupMap.size === 0 && currentRoutes.length > 0) {
+			// 翌日の始発便を取得
+			// 全行先が空の場合、または特定行先の全便が出発済みの場合
+			const needsNextDay =
+				groupMap.size === 0 ||
+				[...groupMap.values()].some(
+					(g) =>
+						!g.isNextDay &&
+						g.departures.length > 0 &&
+						g.departures.every((d) => d.isDeparted),
+				);
+			if (needsNextDay && currentRoutes.length > 0) {
 				const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 				const tomorrowServiceIds = getActiveServiceIds(currentDb, tomorrow);
 
 				if (tomorrowServiceIds.length > 0) {
 					for (const route of currentRoutes) {
+						// 既にグループがあり、全便出発済みでなければスキップ
+						const existingGroup = groupMap.get(route.toStopId);
+						if (
+							existingGroup &&
+							!existingGroup.departures.every((d) => d.isDeparted)
+						) {
+							continue;
+						}
+
 						const sanitizedWalk = Math.max(0, Math.floor(route.walkMinutes));
 						const fromStopIds = getSiblingStopIds(currentDb, route.fromStopId);
 						const toStopIds = getSiblingStopIds(currentDb, route.toStopId);


### PR DESCRIPTION
## Summary

- 経路マップを発車案内の上に配置
- 全便出発済みの行先に対して翌日の始発便を自動取得し、行先プルダウンで常に全行先を選択可能に

## 変更内容

### レイアウト入れ替え
- App.tsx で MapView と DepartureBoard の順序を入れ替え

### 行先フィルタ改善
- useDepartures.ts で、特定行先の全便が出発済みの場合に翌日便を取得
- 既存の「全行先が空の場合のみ翌日便取得」を、行先単位の判定に拡張

## Test plan

- [x] `npm run test` で全 293 テスト通過
- [ ] ブラウザで経路マップが発車案内の上に表示されることを確認
- [ ] 全便出発済みの行先を選択した際に始発以降の便が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)