### PR TITLE
フッターに免責表示・公式リンク・データ出典を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { DepartureBoard } from "./components/DepartureBoard";
 import { ExpiryWarning } from "./components/ExpiryWarning";
-import { Footer } from "./components/Footer";
+import { DataAttribution, Footer } from "./components/Footer";
 import { LoadingSpinner } from "./components/LoadingSpinner";
 import { type MapRoute, MapView } from "./components/MapView";
 import { RouteRegistration } from "./components/RouteRegistration";
@@ -123,6 +123,7 @@ function App() {
 				{db && !loading && !error && (
 					<>
 						<ExpiryWarning expiry={expiry} currentDate={currentDate} />
+						<DataAttribution />
 						{mapRoutes.length > 0 && (
 							<div className="card bg-base-100 shadow-sm">
 								<div className="card-body">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,7 +40,7 @@ export function DataAttribution() {
 						))}
 					</nav>
 				</div>
-				<p className="text-xs text-base-content/50">
+				<p className="text-xs text-base-content/70">
 					交通データ:
 					<a
 						href="https://ckan.hoda.jp/dataset/gtfs-data"
@@ -85,7 +85,7 @@ export function Footer() {
 					</a>
 				))}
 			</nav>
-			<p className="text-xs text-base-content/60">
+			<p className="text-xs text-base-content/70">
 				&copy; 2026 Shota Nishihara
 			</p>
 		</footer>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,61 @@
 /** アプリケーションのフッター */
 export function Footer() {
 	return (
-		<footer className="footer footer-center bg-base-100 text-base-content p-6 mt-auto">
+		<footer className="footer footer-center bg-base-100 text-base-content p-6 mt-auto space-y-4">
+			<section className="text-sm text-base-content/70 space-y-2">
+				<p>このサービスの情報は参考値です。</p>
+				<p>
+					正確な時刻・運賃は各事業者の公式ページをご確認ください。
+				</p>
+				<nav className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+					<a
+						href="https://www.asahikawa-denkikidou.jp/"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						旭川電気軌道
+					</a>
+					<a
+						href="https://www.dohokubus.com/"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						道北バス
+					</a>
+					<a
+						href="https://www.furanobus.jp/"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						ふらのバス
+					</a>
+				</nav>
+			</section>
+			<section className="text-xs text-base-content/50">
+				<p>
+					交通データ:
+					<a
+						href="https://ckan.hoda.jp/dataset/gtfs-data"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						「公共交通GTFSデータ」（HODA 北海道オープンデータプラットフォーム）
+					</a>
+					を加工して作成 /
+					<a
+						href="https://creativecommons.org/licenses/by/4.0/deed.ja"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						CC BY 4.0
+					</a>
+				</p>
+			</section>
 			<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2">
 				<a
 					href="https://x.com/tomio2480"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,90 +1,97 @@
 /** アプリケーションのフッター */
 export function Footer() {
 	return (
-		<footer className="footer footer-center bg-base-100 text-base-content p-6 mt-auto space-y-4">
-			<section className="text-sm text-base-content/70 space-y-2">
-				<p>このサービスの情報は参考値です。</p>
-				<p>
-					正確な時刻・運賃は各事業者の公式ページをご確認ください。
-				</p>
-				<nav className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+		<footer className="mt-auto">
+			{/* 上段: 免責事項・公式リンク・データ出典 */}
+			<div className="bg-base-100 text-base-content p-6 text-center space-y-3">
+				<section className="text-sm text-base-content/70 space-y-2">
+					<p>このサービスの情報は参考値です。</p>
+					<p>
+						正確な時刻・運賃は各事業者の公式ページをご確認ください。
+					</p>
+					<nav className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+						<a
+							href="https://www.asahikawa-denkikidou.jp/"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							旭川電気軌道
+						</a>
+						<a
+							href="https://www.dohokubus.com/"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							道北バス
+						</a>
+						<a
+							href="https://www.furanobus.jp/"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							ふらのバス
+						</a>
+					</nav>
+				</section>
+				<section className="text-xs text-base-content/50">
+					<p>
+						交通データ:
+						<a
+							href="https://ckan.hoda.jp/dataset/gtfs-data"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							「公共交通GTFSデータ」（HODA
+							北海道オープンデータプラットフォーム）
+						</a>
+						を加工して作成 /
+						<a
+							href="https://creativecommons.org/licenses/by/4.0/deed.ja"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							CC BY 4.0
+						</a>
+					</p>
+				</section>
+			</div>
+			{/* 下段: SNS・コピーライト */}
+			<div className="bg-base-300 text-base-content p-4 text-center space-y-2">
+				<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm">
 					<a
-						href="https://www.asahikawa-denkikidou.jp/"
+						href="https://x.com/tomio2480"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="link link-hover"
 					>
-						旭川電気軌道
+						X (Twitter)
 					</a>
 					<a
-						href="https://www.dohokubus.com/"
+						href="https://github.com/sponsors/tomio2480"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="link link-hover"
 					>
-						道北バス
+						GitHub Sponsors
 					</a>
 					<a
-						href="https://www.furanobus.jp/"
+						href="https://github.com/tomio2480/asahikawa-bus-departure"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="link link-hover"
 					>
-						ふらのバス
+						GitHub
 					</a>
 				</nav>
-			</section>
-			<section className="text-xs text-base-content/50">
-				<p>
-					交通データ:
-					<a
-						href="https://ckan.hoda.jp/dataset/gtfs-data"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="link link-hover"
-					>
-						「公共交通GTFSデータ」（HODA 北海道オープンデータプラットフォーム）
-					</a>
-					を加工して作成 /
-					<a
-						href="https://creativecommons.org/licenses/by/4.0/deed.ja"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="link link-hover"
-					>
-						CC BY 4.0
-					</a>
+				<p className="text-xs text-base-content/60">
+					&copy; 2026 Shota Nishihara
 				</p>
-			</section>
-			<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2">
-				<a
-					href="https://x.com/tomio2480"
-					target="_blank"
-					rel="noopener noreferrer"
-					className="link link-hover"
-				>
-					X (Twitter)
-				</a>
-				<a
-					href="https://github.com/sponsors/tomio2480"
-					target="_blank"
-					rel="noopener noreferrer"
-					className="link link-hover"
-				>
-					GitHub Sponsors
-				</a>
-				<a
-					href="https://github.com/tomio2480/asahikawa-bus-departure"
-					target="_blank"
-					rel="noopener noreferrer"
-					className="link link-hover"
-				>
-					GitHub
-				</a>
-			</nav>
-			<aside>
-				<p>&copy; 2026 Shota Nishihara</p>
-			</aside>
+			</div>
 		</footer>
 	);
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,10 @@ export function DataAttribution() {
 					<p>
 						正確な時刻・運賃は各事業者の公式ページをご確認ください。
 					</p>
-					<nav className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+					<nav
+						aria-label="各事業者の公式サイト"
+						className="flex flex-wrap justify-center gap-x-4 gap-y-1"
+					>
 						{OPERATORS.map((op) => (
 							<a
 								key={op.url}
@@ -72,7 +75,10 @@ export function DataAttribution() {
 export function Footer() {
 	return (
 		<footer className="mt-auto bg-base-300 text-base-content p-4 text-center space-y-2">
-			<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm">
+			<nav
+				aria-label="SNS・支援リンク"
+				className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm"
+			>
 				{SOCIAL_LINKS.map((link) => (
 					<a
 						key={link.url}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,15 +20,12 @@ const SOCIAL_LINKS = [
 export function DataAttribution() {
 	return (
 		<div className="card bg-base-100 shadow-sm">
-			<div className="card-body text-center space-y-3">
-				<section className="text-sm text-base-content/70 space-y-2">
-					<p>このサービスの情報は参考値です。</p>
-					<p>
-						正確な時刻・運賃は各事業者の公式ページをご確認ください。
-					</p>
+			<div className="card-body py-3 px-4 text-center space-y-1">
+				<div className="text-sm text-base-content/70">
+					このサービスの情報は参考値です。正確な時刻・運賃は各事業者の公式ページをご確認ください:
 					<nav
 						aria-label="各事業者の公式サイト"
-						className="flex flex-wrap justify-center gap-x-4 gap-y-1"
+						className="inline-flex flex-wrap justify-center gap-x-3 ml-1"
 					>
 						{OPERATORS.map((op) => (
 							<a
@@ -36,36 +33,33 @@ export function DataAttribution() {
 								href={op.url}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="link link-hover"
+								className="link link-primary underline"
 							>
 								{op.name}
 							</a>
 						))}
 					</nav>
-				</section>
-				<section className="text-xs text-base-content/50">
-					<p>
-						交通データ:
-						<a
-							href="https://ckan.hoda.jp/dataset/gtfs-data"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							「公共交通GTFSデータ」（HODA
-							北海道オープンデータプラットフォーム）
-						</a>
-						を加工して作成 /
-						<a
-							href="https://creativecommons.org/licenses/by/4.0/deed.ja"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							CC BY 4.0
-						</a>
-					</p>
-				</section>
+				</div>
+				<p className="text-xs text-base-content/50">
+					交通データ:
+					<a
+						href="https://ckan.hoda.jp/dataset/gtfs-data"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-primary underline ml-1"
+					>
+						「公共交通GTFSデータ」（HODA 北海道オープンデータプラットフォーム）
+					</a>
+					を加工して作成 /
+					<a
+						href="https://creativecommons.org/licenses/by/4.0/deed.ja"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-primary underline ml-1"
+					>
+						CC BY 4.0
+					</a>
+				</p>
 			</div>
 		</div>
 	);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,12 +16,11 @@ const SOCIAL_LINKS = [
 	},
 ] as const;
 
-/** アプリケーションのフッター */
-export function Footer() {
+/** 免責事項・公式リンク・データ出典を表示するカード */
+export function DataAttribution() {
 	return (
-		<footer className="mt-auto">
-			{/* 上段: 免責事項・公式リンク・データ出典 */}
-			<div className="bg-base-100 text-base-content p-6 text-center space-y-3">
+		<div className="card bg-base-100 shadow-sm">
+			<div className="card-body text-center space-y-3">
 				<section className="text-sm text-base-content/70 space-y-2">
 					<p>このサービスの情報は参考値です。</p>
 					<p>
@@ -65,25 +64,30 @@ export function Footer() {
 					</p>
 				</section>
 			</div>
-			{/* 下段: SNS・コピーライト */}
-			<div className="bg-base-300 text-base-content p-4 text-center space-y-2">
-				<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm">
-					{SOCIAL_LINKS.map((link) => (
-						<a
-							key={link.url}
-							href={link.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							{link.name}
-						</a>
-					))}
-				</nav>
-				<p className="text-xs text-base-content/60">
-					&copy; 2026 Shota Nishihara
-				</p>
-			</div>
+		</div>
+	);
+}
+
+/** アプリケーションのフッター */
+export function Footer() {
+	return (
+		<footer className="mt-auto bg-base-300 text-base-content p-4 text-center space-y-2">
+			<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm">
+				{SOCIAL_LINKS.map((link) => (
+					<a
+						key={link.url}
+						href={link.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="link link-hover"
+					>
+						{link.name}
+					</a>
+				))}
+			</nav>
+			<p className="text-xs text-base-content/60">
+				&copy; 2026 Shota Nishihara
+			</p>
 		</footer>
 	);
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,21 @@
+const OPERATORS = [
+	{ name: "旭川電気軌道", url: "https://www.asahikawa-denkikidou.jp/" },
+	{ name: "道北バス", url: "https://www.dohokubus.com/" },
+	{ name: "ふらのバス", url: "https://www.furanobus.jp/" },
+] as const;
+
+const SOCIAL_LINKS = [
+	{ name: "X (Twitter)", url: "https://x.com/tomio2480" },
+	{
+		name: "GitHub Sponsors",
+		url: "https://github.com/sponsors/tomio2480",
+	},
+	{
+		name: "GitHub",
+		url: "https://github.com/tomio2480/asahikawa-bus-departure",
+	},
+] as const;
+
 /** アプリケーションのフッター */
 export function Footer() {
 	return (
@@ -10,30 +28,17 @@ export function Footer() {
 						正確な時刻・運賃は各事業者の公式ページをご確認ください。
 					</p>
 					<nav className="flex flex-wrap justify-center gap-x-4 gap-y-1">
-						<a
-							href="https://www.asahikawa-denkikidou.jp/"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							旭川電気軌道
-						</a>
-						<a
-							href="https://www.dohokubus.com/"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							道北バス
-						</a>
-						<a
-							href="https://www.furanobus.jp/"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="link link-hover"
-						>
-							ふらのバス
-						</a>
+						{OPERATORS.map((op) => (
+							<a
+								key={op.url}
+								href={op.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="link link-hover"
+							>
+								{op.name}
+							</a>
+						))}
 					</nav>
 				</section>
 				<section className="text-xs text-base-content/50">
@@ -63,30 +68,17 @@ export function Footer() {
 			{/* 下段: SNS・コピーライト */}
 			<div className="bg-base-300 text-base-content p-4 text-center space-y-2">
 				<nav className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm">
-					<a
-						href="https://x.com/tomio2480"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="link link-hover"
-					>
-						X (Twitter)
-					</a>
-					<a
-						href="https://github.com/sponsors/tomio2480"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="link link-hover"
-					>
-						GitHub Sponsors
-					</a>
-					<a
-						href="https://github.com/tomio2480/asahikawa-bus-departure"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="link link-hover"
-					>
-						GitHub
-					</a>
+					{SOCIAL_LINKS.map((link) => (
+						<a
+							key={link.url}
+							href={link.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="link link-hover"
+						>
+							{link.name}
+						</a>
+					))}
 				</nav>
 				<p className="text-xs text-base-content/60">
 					&copy; 2026 Shota Nishihara

--- a/test/Footer.test.tsx
+++ b/test/Footer.test.tsx
@@ -49,4 +49,66 @@ describe("Footer", () => {
 			expect(link).toHaveAttribute("rel", "noopener noreferrer");
 		}
 	});
+
+	describe("免責表示と公式リンク", () => {
+		it("免責表示が表示される", () => {
+			render(<Footer />);
+			expect(
+				screen.getByText("このサービスの情報は参考値です。"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/正確な時刻・運賃は各事業者の公式ページをご確認ください/,
+				),
+			).toBeInTheDocument();
+		});
+
+		it("旭川電気軌道の公式リンクが正しい URL を持つ", () => {
+			render(<Footer />);
+			const link = screen.getByRole("link", { name: "旭川電気軌道" });
+			expect(link).toHaveAttribute(
+				"href",
+				"https://www.asahikawa-denkikidou.jp/",
+			);
+		});
+
+		it("道北バスの公式リンクが正しい URL を持つ", () => {
+			render(<Footer />);
+			const link = screen.getByRole("link", { name: "道北バス" });
+			expect(link).toHaveAttribute("href", "https://www.dohokubus.com/");
+		});
+
+		it("ふらのバスの公式リンクが正しい URL を持つ", () => {
+			render(<Footer />);
+			const link = screen.getByRole("link", { name: "ふらのバス" });
+			expect(link).toHaveAttribute("href", "https://www.furanobus.jp/");
+		});
+	});
+
+	describe("データ出典表示", () => {
+		it("HODA のデータ出典が表示される", () => {
+			render(<Footer />);
+			expect(screen.getByText(/加工して作成/)).toBeInTheDocument();
+		});
+
+		it("HODA データセットへのリンクが正しい URL を持つ", () => {
+			render(<Footer />);
+			const link = screen.getByRole("link", {
+				name: /公共交通GTFSデータ/,
+			});
+			expect(link).toHaveAttribute(
+				"href",
+				"https://ckan.hoda.jp/dataset/gtfs-data",
+			);
+		});
+
+		it("CC BY 4.0 ライセンスへのリンクが表示される", () => {
+			render(<Footer />);
+			const link = screen.getByRole("link", { name: /CC BY 4\.0/ });
+			expect(link).toHaveAttribute(
+				"href",
+				"https://creativecommons.org/licenses/by/4.0/deed.ja",
+			);
+		});
+	});
 });

--- a/test/Footer.test.tsx
+++ b/test/Footer.test.tsx
@@ -47,6 +47,7 @@ describe("Footer", () => {
 		const links = screen.getAllByRole("link");
 		for (const link of links) {
 			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+			expect(link).toHaveAttribute("target", "_blank");
 		}
 	});
 

--- a/test/Footer.test.tsx
+++ b/test/Footer.test.tsx
@@ -57,7 +57,7 @@ describe("DataAttribution", () => {
 		it("免責表示が表示される", () => {
 			render(<DataAttribution />);
 			expect(
-				screen.getByText("このサービスの情報は参考値です。"),
+				screen.getByText(/このサービスの情報は参考値です/),
 			).toBeInTheDocument();
 			expect(
 				screen.getByText(

--- a/test/Footer.test.tsx
+++ b/test/Footer.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { Footer } from "../src/components/Footer";
+import { DataAttribution, Footer } from "../src/components/Footer";
 
 afterEach(() => {
 	cleanup();
@@ -42,7 +42,7 @@ describe("Footer", () => {
 		expect(links[0]).toHaveAttribute("target", "_blank");
 	});
 
-	it("外部リンクに rel='noopener noreferrer' が設定されている", () => {
+	it("外部リンクに rel='noopener noreferrer' と target='_blank' が設定されている", () => {
 		render(<Footer />);
 		const links = screen.getAllByRole("link");
 		for (const link of links) {
@@ -50,10 +50,12 @@ describe("Footer", () => {
 			expect(link).toHaveAttribute("target", "_blank");
 		}
 	});
+});
 
+describe("DataAttribution", () => {
 	describe("免責表示と公式リンク", () => {
 		it("免責表示が表示される", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			expect(
 				screen.getByText("このサービスの情報は参考値です。"),
 			).toBeInTheDocument();
@@ -65,7 +67,7 @@ describe("Footer", () => {
 		});
 
 		it("旭川電気軌道の公式リンクが正しい URL を持つ", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			const link = screen.getByRole("link", { name: "旭川電気軌道" });
 			expect(link).toHaveAttribute(
 				"href",
@@ -74,13 +76,13 @@ describe("Footer", () => {
 		});
 
 		it("道北バスの公式リンクが正しい URL を持つ", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			const link = screen.getByRole("link", { name: "道北バス" });
 			expect(link).toHaveAttribute("href", "https://www.dohokubus.com/");
 		});
 
 		it("ふらのバスの公式リンクが正しい URL を持つ", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			const link = screen.getByRole("link", { name: "ふらのバス" });
 			expect(link).toHaveAttribute("href", "https://www.furanobus.jp/");
 		});
@@ -88,12 +90,12 @@ describe("Footer", () => {
 
 	describe("データ出典表示", () => {
 		it("HODA のデータ出典が表示される", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			expect(screen.getByText(/加工して作成/)).toBeInTheDocument();
 		});
 
 		it("HODA データセットへのリンクが正しい URL を持つ", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			const link = screen.getByRole("link", {
 				name: /公共交通GTFSデータ/,
 			});
@@ -104,12 +106,21 @@ describe("Footer", () => {
 		});
 
 		it("CC BY 4.0 ライセンスへのリンクが表示される", () => {
-			render(<Footer />);
+			render(<DataAttribution />);
 			const link = screen.getByRole("link", { name: /CC BY 4\.0/ });
 			expect(link).toHaveAttribute(
 				"href",
 				"https://creativecommons.org/licenses/by/4.0/deed.ja",
 			);
 		});
+	});
+
+	it("外部リンクに rel='noopener noreferrer' と target='_blank' が設定されている", () => {
+		render(<DataAttribution />);
+		const links = screen.getAllByRole("link");
+		for (const link of links) {
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+			expect(link).toHaveAttribute("target", "_blank");
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- HODA の GTFS データ（CC BY 4.0）の出典表示と改変の明示を追加し、ライセンス要件を充足
- 各事業者（旭川電気軌道・道北バス・ふらのバス）の公式サイトへのリンクを追加
- 「このサービスの情報は参考値です」の免責表示を追加し、正確な時刻・運賃の参照先を明示

## Test plan
- [ ] フッターに免責表示テキストが表示されることを確認
- [ ] 各事業者の公式リンクが正しい URL で表示されることを確認
- [ ] HODA データセットと CC BY 4.0 ライセンスへのリンクが表示されることを確認
- [ ] コピーライトと作者リンクが引き続き表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * データソース帰属表示とプロバイダー情報を表示する新しいコンポーネントを追加しました。

* **スタイル**
  * フッターのレイアウトとスタイルを改善し、より整理された表示になりました。
  * リンクの表示方法を動的に変更し、一貫性を向上させました。

* **テスト**
  * 新しいコンポーネントと既存フッターの包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->