### PR TITLE
行き先フィルタを複数選択タグ UI に変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,21 +52,39 @@ function App() {
 	}, []);
 
 
-	const [selectedDestination, setSelectedDestination] = useState("all");
-	const effectiveDestination = useMemo(() => {
-		if (selectedDestination === "all") return "all";
-		return groups.some((g) => g.toStopId === selectedDestination)
-			? selectedDestination
-			: "all";
-	}, [selectedDestination, groups]);
+	const [selectedDestinations, setSelectedDestinations] = useState<
+		Set<string>
+	>(new Set());
+	const effectiveDestinations = useMemo(() => {
+		if (selectedDestinations.size === 0) return new Set<string>();
+		const valid = new Set<string>();
+		for (const id of selectedDestinations) {
+			if (groups.some((g) => g.toStopId === id)) {
+				valid.add(id);
+			}
+		}
+		return valid;
+	}, [selectedDestinations, groups]);
+
+	const handleDestinationToggle = useCallback((id: string) => {
+		setSelectedDestinations((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	}, []);
 
 	const mapRoutes = useMemo<MapRoute[]>(() => {
 		const seen = new Set<string>();
 		const result: MapRoute[] = [];
 		const filteredGroups =
-			effectiveDestination === "all"
+			effectiveDestinations.size === 0
 				? groups
-				: groups.filter((g) => g.toStopId === effectiveDestination);
+				: groups.filter((g) => effectiveDestinations.has(g.toStopId));
 		for (const group of filteredGroups) {
 			for (const dep of group.departures) {
 				const key = `${dep.tripId}-${dep.fromStopId}-${dep.toStopId}`;
@@ -83,7 +101,7 @@ function App() {
 			}
 		}
 		return result;
-	}, [groups, effectiveDestination]);
+	}, [groups, effectiveDestinations]);
 
 	const { preference, changeTheme } = useTheme();
 
@@ -148,8 +166,8 @@ function App() {
 							onRouteHover={handleRouteHover}
 							pinnedRouteKey={pinnedRouteKey}
 							onRoutePinToggle={handleRoutePinToggle}
-							selectedDestination={effectiveDestination}
-							onDestinationChange={setSelectedDestination}
+							selectedDestinations={effectiveDestinations}
+							onDestinationToggle={handleDestinationToggle}
 						/>
 						<RouteRegistration
 							db={db}

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -53,6 +53,9 @@ function formatUpdatedTime(date: Date): string {
 /** スクロール領域の最大高さ（Tailwind の max-h-60 = 15rem 相当） */
 const SCROLL_MAX_HEIGHT_CLASS = "max-h-60";
 
+/** selectedDestinations のデフォルト値（参照安定性のためモジュールスコープで保持） */
+const EMPTY_DESTINATIONS = new Set<string>();
+
 /** ソート可能なカラム */
 type SortKey = "leaveByTime" | "departureTime" | "arrivalTime";
 
@@ -69,7 +72,7 @@ export function DepartureBoard({
 	onRouteHover,
 	pinnedRouteKey,
 	onRoutePinToggle,
-	selectedDestinations = new Set<string>(),
+	selectedDestinations = EMPTY_DESTINATIONS,
 	onDestinationToggle,
 }: DepartureBoardProps) {
 

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -225,7 +225,7 @@ export function DepartureBoard({
 												key={stopId}
 												type="button"
 												aria-pressed={isActive}
-												className={`badge cursor-pointer ${isActive ? "badge-primary" : "badge-outline"}`}
+												className={`badge cursor-pointer hover:opacity-80 transition-opacity ${isActive ? "badge-primary" : "badge-outline"}`}
 												onClick={() =>
 													onDestinationToggle?.(stopId)
 												}

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -219,18 +219,18 @@ export function DepartureBoard({
 								>
 									{[...destinations.entries()].map(([stopId, name]) => {
 										const isActive =
-											selectedDestinations.size > 0 &&
 											selectedDestinations.has(stopId);
 										return (
 											<button
 												key={stopId}
 												type="button"
+												aria-pressed={isActive}
 												className={`badge cursor-pointer ${isActive ? "badge-primary" : "badge-outline"}`}
 												onClick={() =>
 													onDestinationToggle?.(stopId)
 												}
 											>
-												{name}
+												{name || stopId}
 											</button>
 										);
 									})}

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -19,10 +19,10 @@ type DepartureBoardProps = {
 	pinnedRouteKey?: string | null;
 	/** 経路クリック時のトグルコールバック */
 	onRoutePinToggle?: (key: string) => void;
-	/** 現在選択中の行先フィルタ値（"all" で全行先） */
-	selectedDestination?: string;
-	/** 行先フィルタ変更時に呼ばれるコールバック */
-	onDestinationChange?: (destinationId: string) => void;
+	/** 選択中の行先 ID の集合（空集合で全行先） */
+	selectedDestinations?: Set<string>;
+	/** 行先タグクリック時のトグルコールバック */
+	onDestinationToggle?: (destinationId: string) => void;
 };
 
 /** HH:MM:SS または H:MM:SS 形式の時刻を HH:MM に短縮する */
@@ -69,8 +69,8 @@ export function DepartureBoard({
 	onRouteHover,
 	pinnedRouteKey,
 	onRoutePinToggle,
-	selectedDestination = "all",
-	onDestinationChange,
+	selectedDestinations = new Set<string>(),
+	onDestinationToggle,
 }: DepartureBoardProps) {
 
 	// 行先の選択肢（ドロップダウン用。フィルタ中も全選択肢を表示する）
@@ -87,10 +87,10 @@ export function DepartureBoard({
 	// 選択中の行先でグループを絞り込む
 	const visibleGroups = useMemo(
 		() =>
-			selectedDestination === "all"
+			selectedDestinations.size === 0
 				? groups
-				: groups.filter((g) => g.toStopId === selectedDestination),
-		[groups, selectedDestination],
+				: groups.filter((g) => selectedDestinations.has(g.toStopId)),
+		[groups, selectedDestinations],
 	);
 
 	const [sortKey, setSortKey] = useState<SortKey>("departureTime");
@@ -212,19 +212,29 @@ export function DepartureBoard({
 								</span>
 							)}
 							{destinations.size > 1 && (
-								<select
+								<div
+									className="flex flex-wrap gap-1"
+									role="group"
 									aria-label="行き先で絞り込む"
-									className="select select-sm select-bordered"
-									value={selectedDestination}
-									onChange={(e) => onDestinationChange?.(e.target.value)}
 								>
-									<option value="all">全ての行先</option>
-									{[...destinations.entries()].map(([stopId, name]) => (
-										<option key={stopId} value={stopId}>
-											{name}
-										</option>
-									))}
-								</select>
+									{[...destinations.entries()].map(([stopId, name]) => {
+										const isActive =
+											selectedDestinations.size > 0 &&
+											selectedDestinations.has(stopId);
+										return (
+											<button
+												key={stopId}
+												type="button"
+												className={`badge cursor-pointer ${isActive ? "badge-primary" : "badge-outline"}`}
+												onClick={() =>
+													onDestinationToggle?.(stopId)
+												}
+											>
+												{name}
+											</button>
+										);
+									})}
+								</div>
 							)}
 						</div>
 						<div

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -95,7 +95,7 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(headsigns.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("複数の行先がプルダウンの選択肢に表示される", () => {
+	it("複数の行先がタグとして表示される", () => {
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -125,23 +125,13 @@ describe("DepartureBoard コンポーネント", () => {
 				hasRoutes={true}
 			/>,
 		);
-		const select = screen.getByRole("combobox");
-		expect(select).toBeInTheDocument();
-		const options = screen.getAllByRole("option");
-		expect(options).toHaveLength(3);
-		expect(options.map((o) => o.textContent)).toEqual([
-			"全ての行先",
-			"市役所前",
-			"旭川四条駅",
-		]);
-		expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual([
-			"all",
-			"test:S002",
-			"test:S003",
-		]);
+		const tag1 = screen.getByRole("button", { name: "市役所前" });
+		const tag2 = screen.getByRole("button", { name: "旭川四条駅" });
+		expect(tag1).toBeInTheDocument();
+		expect(tag2).toBeInTheDocument();
 	});
 
-	it("selectedDestination で行先がフィルタされる", () => {
+	it("selectedDestinations で行先がフィルタされる", () => {
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -169,7 +159,7 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
-				selectedDestination="test:S003"
+				selectedDestinations={new Set(["test:S003"])}
 			/>,
 		);
 
@@ -478,7 +468,7 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
-				selectedDestination="registered:S003"
+				selectedDestinations={new Set(["registered:S003"])}
 			/>,
 		);
 
@@ -486,8 +476,8 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(screen.queryByText("市役所方面")).not.toBeInTheDocument();
 	});
 
-	it("onDestinationChange がプルダウン操作で呼ばれる", () => {
-		const onChange = vi.fn();
+	it("onDestinationToggle がタグクリックで呼ばれる", () => {
+		const onToggle = vi.fn();
 		const groups = [
 			makeGroup(),
 			makeGroup({
@@ -515,14 +505,105 @@ describe("DepartureBoard コンポーネント", () => {
 				lastUpdated={new Date()}
 				error={null}
 				hasRoutes={true}
-				onDestinationChange={onChange}
+				onDestinationToggle={onToggle}
 			/>,
 		);
 
-		const select = screen.getByRole("combobox");
-		fireEvent.change(select, { target: { value: "test:S003" } });
+		const tag = screen.getByRole("button", { name: "旭川四条駅" });
+		fireEvent.click(tag);
 
-		expect(onChange).toHaveBeenCalledWith("test:S003");
+		expect(onToggle).toHaveBeenCalledWith("test:S003");
+	});
+
+	it("複数の行き先を選択するとそれらのみ表示される", () => {
+		const groups = [
+			makeGroup(),
+			makeGroup({
+				toStopId: "test:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T003",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+			makeGroup({
+				toStopId: "test:S004",
+				toStopName: "旭川空港",
+				departures: [
+					{
+						tripId: "T004",
+						routeId: "R003",
+						routeName: "77番",
+						headsign: "空港方面",
+						departureTime: "08:30:00",
+						arrivalTime: "09:00:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S004",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				selectedDestinations={new Set(["test:S002", "test:S003"])}
+			/>,
+		);
+
+		expect(screen.getAllByText("市役所方面").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("四条方面").length).toBeGreaterThan(0);
+		expect(screen.queryByText("空港方面")).not.toBeInTheDocument();
+	});
+
+	it("何も選択していない場合は全行き先が表示される", () => {
+		const groups = [
+			makeGroup(),
+			makeGroup({
+				toStopId: "test:S003",
+				toStopName: "旭川四条駅",
+				departures: [
+					{
+						tripId: "T003",
+						routeId: "R002",
+						routeName: "2番",
+						headsign: "四条方面",
+						departureTime: "08:15:00",
+						arrivalTime: "08:45:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			}),
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+				selectedDestinations={new Set()}
+			/>,
+		);
+
+		expect(screen.getAllByText("市役所方面").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("四条方面").length).toBeGreaterThan(0);
 	});
 
 	it("ホバー時に onRouteHover が routeId を含むキーで呼ばれる", async () => {

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -129,6 +129,9 @@ describe("DepartureBoard コンポーネント", () => {
 		const tag2 = screen.getByRole("button", { name: "旭川四条駅" });
 		expect(tag1).toBeInTheDocument();
 		expect(tag2).toBeInTheDocument();
+		// 未選択状態では aria-pressed が false
+		expect(tag1).toHaveAttribute("aria-pressed", "false");
+		expect(tag2).toHaveAttribute("aria-pressed", "false");
 	});
 
 	it("selectedDestinations で行先がフィルタされる", () => {


### PR DESCRIPTION
## Summary
- 行き先フィルタを単一選択 `<select>` から DaisyUI badge ベースの複数選択タグ UI に変更
- タグをクリックして行き先の選択/解除をトグル（選択中: `badge-primary`、未選択: `badge-outline`）
- 未選択（空集合）は全行き先を表示、複数選択時は選択した行き先のみ表示
- 発車案内テーブルと経路マップの両方が選択に連動

## Test plan
- [ ] 複数の行き先がタグとして表示されることを確認
- [ ] タグをクリックして選択/解除が切り替わることを確認
- [ ] 複数タグを選択すると、選択した行き先の便のみ表示されることを確認
- [ ] 何も選択していない状態で全行き先が表示されることを確認
- [ ] 地図の経路も選択に連動してフィルタされることを確認
- [ ] 行き先が 1 件の場合はタグが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 目的地フィルタが複数選択に対応しました。複数の目的地を同時に選択して、該当する出発時刻のみを表示できるようになりました。

* **ユーザーインターフェース**
  * 目的地選択がドロップダウンメニューからボタンベースのセレクタに変更されました。より直感的に複数の目的地を選択可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->