### PR TITLE
翌日便を当日便の後に表示するようソート順を修正

### DIFF
--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -121,10 +121,13 @@ export function DepartureBoard({
 		[visibleGroups],
 	);
 
-	// ソート適用
+	// ソート適用（翌日便は常に当日便の後に配置）
 	const allDepartures = useMemo(() => {
 		const dir = sortDirection === "asc" ? 1 : -1;
 		return [...flattenedDepartures].sort((a, b) => {
+			const aNext = a.isNextDay ? 1 : 0;
+			const bNext = b.isNextDay ? 1 : 0;
+			if (aNext !== bNext) return aNext - bNext;
 			const aVal = (a[sortKey] as string | undefined) ?? "";
 			const bVal = (b[sortKey] as string | undefined) ?? "";
 			return dir * aVal.localeCompare(bVal);

--- a/src/components/DepartureBoard.tsx
+++ b/src/components/DepartureBoard.tsx
@@ -288,6 +288,11 @@ export function DepartureBoard({
 															出発済
 														</span>
 													)}
+													{dep.isNextDay && !dep.isDeparted && (
+														<span className="ml-1 badge badge-sm badge-outline">
+															始発以降
+														</span>
+													)}
 												</td>
 												<td>{dep.fromStopName ?? "-"}</td>
 												<td className={`font-mono ${sortKey === "departureTime" ? "bg-base-300/50" : ""}`}>

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -210,6 +210,64 @@ describe("DepartureBoard コンポーネント", () => {
 		expect(times).toEqual(["08:00", "08:15", "09:00"]);
 	});
 
+	it("翌日便は当日便の後に表示される", () => {
+		const groups: DepartureGroup[] = [
+			{
+				toStopId: "test:S002",
+				toStopName: "旭川空港",
+				departures: [
+					{
+						tripId: "T010",
+						routeId: "R001",
+						routeName: "77番",
+						headsign: "旭川空港行き",
+						departureTime: "10:14:00",
+						arrivalTime: "10:37:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S002",
+						shapeId: null,
+						fare: null,
+					},
+				],
+				isNextDay: true,
+			},
+			{
+				toStopId: "test:S003",
+				toStopName: "旭川駅",
+				departures: [
+					{
+						tripId: "T020",
+						routeId: "R002",
+						routeName: "83番",
+						headsign: "旭川駅前行き",
+						departureTime: "19:46:00",
+						arrivalTime: "20:11:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			},
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+
+		const tbody = screen.getAllByRole("rowgroup")[1];
+		const rows = within(tbody).getAllByRole("row");
+		const headsigns = rows.map(
+			(row) => within(row).getAllByRole("cell")[6].textContent,
+		);
+		// 当日便（19:46）が先、翌日便（10:14）が後
+		expect(headsigns).toEqual(["旭川駅前行き", "旭川空港行き"]);
+	});
+
 	it("発車予定がない場合はメッセージを表示する", () => {
 		render(
 			<DepartureBoard

--- a/test/DepartureBoard.test.tsx
+++ b/test/DepartureBoard.test.tsx
@@ -266,6 +266,72 @@ describe("DepartureBoard コンポーネント", () => {
 		);
 		// 当日便（19:46）が先、翌日便（10:14）が後
 		expect(headsigns).toEqual(["旭川駅前行き", "旭川空港行き"]);
+
+		// 降順に切り替えても翌日便は末尾のまま
+		const departureHeader = screen.getAllByRole("columnheader")[2];
+		fireEvent.click(departureHeader);
+		const rowsDesc = within(tbody).getAllByRole("row");
+		const headsignsDesc = rowsDesc.map(
+			(row) => within(row).getAllByRole("cell")[6].textContent,
+		);
+		expect(headsignsDesc).toEqual(["旭川駅前行き", "旭川空港行き"]);
+	});
+
+	it("翌日便に始発以降バッジが表示される", () => {
+		const groups: DepartureGroup[] = [
+			{
+				toStopId: "test:S002",
+				toStopName: "旭川空港",
+				departures: [
+					{
+						tripId: "T010",
+						routeId: "R001",
+						routeName: "77番",
+						headsign: "旭川空港行き",
+						departureTime: "10:14:00",
+						arrivalTime: "10:37:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S002",
+						shapeId: null,
+						fare: null,
+					},
+				],
+				isNextDay: true,
+			},
+			{
+				toStopId: "test:S003",
+				toStopName: "旭川駅",
+				departures: [
+					{
+						tripId: "T020",
+						routeId: "R002",
+						routeName: "83番",
+						headsign: "旭川駅前行き",
+						departureTime: "19:46:00",
+						arrivalTime: "20:11:00",
+						fromStopId: "test:S001",
+						toStopId: "test:S003",
+						shapeId: null,
+						fare: null,
+					},
+				],
+			},
+		];
+		render(
+			<DepartureBoard
+				groups={groups}
+				lastUpdated={new Date()}
+				error={null}
+				hasRoutes={true}
+			/>,
+		);
+
+		const tbody = screen.getAllByRole("rowgroup")[1];
+		const rows = within(tbody).getAllByRole("row");
+		// 翌日便の行（2行目）に「始発以降」バッジがある
+		expect(within(rows[1]).getByText("始発以降")).toBeInTheDocument();
+		// 当日便の行（1行目）にはない
+		expect(within(rows[0]).queryByText("始発以降")).not.toBeInTheDocument();
 	});
 
 	it("発車予定がない場合はメッセージを表示する", () => {


### PR DESCRIPTION
## Summary
- 翌日の始発以降の便（`isNextDay: true`）が発車時刻の数値が小さいために一覧の上に表示される問題を修正
- ソート時に `isNextDay` フラグで当日便と翌日便を分離し、翌日便は常に末尾に配置
- 発車/到着/出発目安のソートキーによる並べ替えは、当日便・翌日便それぞれの中で適用される

## Test plan
- [ ] 当日の便が先、翌日の始発便が後に表示されることを確認
- [ ] 発車時刻でソートしても翌日便が当日便の前に来ないことを確認
- [ ] ソート方向（昇順/降順）を切り替えても翌日便の位置が末尾のまま維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 出発ボードのソート機能を改善。翌日の出発便が常に同日の出発便の後に表示されるよう順序付けを最適化しました。

* **Tests**
  * 翌日の出発便の並び順を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->