### PR TITLE
feat: 通知タイミング確定と経路トグルの UX 改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,14 @@ import { LoadingSpinner } from "./components/LoadingSpinner";
 import { type MapRoute, MapView } from "./components/MapView";
 import { RouteRegistration } from "./components/RouteRegistration";
 import { RouteTransfer } from "./components/RouteTransfer";
+import { ToastContainer } from "./components/Toast";
 import { useDatabase } from "./hooks/useDatabase";
 import { useDepartures } from "./hooks/useDepartures";
 import { useNotification } from "./hooks/useNotification";
 import { useNotificationSettings } from "./hooks/useNotificationSettings";
 import { useRoutes } from "./hooks/useRoutes";
 import { type ThemePreference, useTheme } from "./hooks/useTheme";
+import { ToastProvider } from "./hooks/useToast";
 import { getDataExpiry } from "./lib/data-expiry";
 
 /** 現在日付を YYYYMMDD 形式で返す（ローカル） */
@@ -19,7 +21,7 @@ function getCurrentDateStr(): string {
 	return new Date().toLocaleDateString("sv-SE").replace(/-/g, "");
 }
 
-function App() {
+function AppContent() {
 	const { db, error: dbError, loading: dbLoading } = useDatabase();
 	const {
 		routes,
@@ -53,10 +55,9 @@ function App() {
 		setPinnedRouteKey((prev) => (prev === key ? null : key));
 	}, []);
 
-
-	const [selectedDestinations, setSelectedDestinations] = useState<
-		Set<string>
-	>(new Set());
+	const [selectedDestinations, setSelectedDestinations] = useState<Set<string>>(
+		new Set(),
+	);
 	const effectiveDestinations = useMemo(() => {
 		if (selectedDestinations.size === 0) return new Set<string>();
 		const valid = new Set<string>();
@@ -107,10 +108,8 @@ function App() {
 
 	const { preference, changeTheme } = useTheme();
 
-	const {
-		minutes: notifyBeforeMinutes,
-		setMinutes: setNotifyBeforeMinutes,
-	} = useNotificationSettings();
+	const { minutes: notifyBeforeMinutes, setMinutes: setNotifyBeforeMinutes } =
+		useNotificationSettings();
 
 	const allDeparturesForNotification = useMemo(
 		() =>
@@ -147,9 +146,7 @@ function App() {
 							aria-label="テーマ切り替え"
 							className="select select-sm select-bordered"
 							value={preference}
-							onChange={(e) =>
-								changeTheme(e.target.value as ThemePreference)
-							}
+							onChange={(e) => changeTheme(e.target.value as ThemePreference)}
 						>
 							<option value="system">デバイス設定</option>
 							<option value="light">ライト</option>
@@ -214,7 +211,21 @@ function App() {
 				)}
 			</main>
 			<Footer />
+			<ToastContainer />
 		</div>
+	);
+}
+
+/**
+ * アプリのルートコンポーネント。
+ * ToastProvider で AppContent を包み、配下の useToast 呼び出し
+ * (RouteRegistration 等) が常に有効な Context を得られるようにする。
+ */
+function App() {
+	return (
+		<ToastProvider>
+			<AppContent />
+		</ToastProvider>
 	);
 }
 

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -113,14 +113,18 @@ export function RouteRegistration({
 	 * 通知分前入力の確定処理。
 	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、onNotifyBeforeMinutesChange
 	 * に伝播する。呼び出し元が throw した場合はエラートーストで通知する。
+	 * コールバック未指定時は optional chaining で silently no-op するだけでは
+	 * 「設定しました」トーストが誤表示されるため、明示的にガードする。
 	 */
 	const commitNotifyInput = () => {
 		if (!canCommitNotifyInput) return;
+		if (!onNotifyBeforeMinutesChange) return;
 		try {
-			onNotifyBeforeMinutesChange?.(notifyInputParsed);
-			showToast(`通知タイミングを ${notifyInputParsed} 分前に設定しました`, {
-				variant: "success",
-			});
+			onNotifyBeforeMinutesChange(notifyInputParsed);
+			showToast(
+				`発車の ${notifyInputParsed} 分前に通知するように設定しました`,
+				{ variant: "success" },
+			);
 		} catch (err) {
 			const detail = err instanceof Error ? err.message : String(err);
 			showToast(`通知タイミングを設定できませんでした: ${detail}`, {

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Database } from "sql.js";
+import { useToast } from "../hooks/useToast";
 import { type StopSearchResult, getStopName } from "../lib/stop-search";
 import type { RegisteredRouteEntry, RouteEntry } from "../types/route-entry";
 import { StopSearch } from "./StopSearch";
@@ -75,10 +76,16 @@ export function RouteRegistration({
 	const [editingId, setEditingId] = useState<number | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// トグル処理中の経路 ID。submitting と分離することで、フォーム側の
+	// 「登録」ボタンが通知 ON/OFF のたびに「保存中...」へ切り替わるなどの
+	// 表示揺れを防ぐ。トグル処理は複数同時実行させないため null | number で十分。
+	const [togglingRouteId, setTogglingRouteId] = useState<number | null>(null);
+
+	const { showToast } = useToast();
 
 	// 通知分前入力のローカル表示値（一時クリアを許容するため string で管理）
-	const [notifyInputValue, setNotifyInputValue] = useState(
-		() => (notifyBeforeMinutes !== undefined ? String(notifyBeforeMinutes) : ""),
+	const [notifyInputValue, setNotifyInputValue] = useState(() =>
+		notifyBeforeMinutes !== undefined ? String(notifyBeforeMinutes) : "",
 	);
 	// 外部から prop が変更された場合（localStorage 初期読込等）に同期する
 	useEffect(() => {
@@ -88,19 +95,37 @@ export function RouteRegistration({
 	}, [notifyBeforeMinutes]);
 
 	/**
+	 * 現在の入力値が有効（整数かつ 1〜60）かどうか。
+	 * UI 属性 min="1" max="60" step="1" と意図を揃える。
+	 */
+	const notifyInputParsed = Number(notifyInputValue);
+	const isNotifyInputValid =
+		notifyInputValue.trim() !== "" &&
+		Number.isInteger(notifyInputParsed) &&
+		notifyInputParsed >= 1 &&
+		notifyInputParsed <= 60;
+	const isNotifyInputChanged =
+		notifyBeforeMinutes === undefined ||
+		notifyInputParsed !== notifyBeforeMinutes;
+	const canCommitNotifyInput = isNotifyInputValid && isNotifyInputChanged;
+
+	/**
 	 * 通知分前入力の確定処理。
-	 * blur / Enter キー押下時に呼び出され、表示値を検証して有効なら
-	 * onNotifyBeforeMinutesChange に伝播、無効なら直前の有効値に戻す。
+	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、onNotifyBeforeMinutesChange
+	 * に伝播する。呼び出し元が throw した場合はエラートーストで通知する。
 	 */
 	const commitNotifyInput = () => {
-		const v = Number(notifyInputValue);
-		// UI 属性 min="1" max="60" step="1" と意図を揃える
-		if (Number.isInteger(v) && v >= 1 && v <= 60) {
-			onNotifyBeforeMinutesChange?.(v);
-			return;
-		}
-		if (notifyBeforeMinutes !== undefined) {
-			setNotifyInputValue(String(notifyBeforeMinutes));
+		if (!canCommitNotifyInput) return;
+		try {
+			onNotifyBeforeMinutesChange?.(notifyInputParsed);
+			showToast(`通知タイミングを ${notifyInputParsed} 分前に設定しました`, {
+				variant: "success",
+			});
+		} catch (err) {
+			const detail = err instanceof Error ? err.message : String(err);
+			showToast(`通知タイミングを設定できませんでした: ${detail}`, {
+				variant: "error",
+			});
 		}
 	};
 
@@ -173,7 +198,14 @@ export function RouteRegistration({
 				setSubmitting(false);
 			}
 		},
-		[form, editingId, onAdd, onUpdate, resetForm, onRequestNotificationPermission],
+		[
+			form,
+			editingId,
+			onAdd,
+			onUpdate,
+			resetForm,
+			onRequestNotificationPermission,
+		],
 	);
 
 	const handleEdit = useCallback(
@@ -314,11 +346,9 @@ export function RouteRegistration({
 					<div className="card-body">
 						<h2 className="card-title">登録済み経路</h2>
 						{notifyPermission === "denied" && (
-							<div
-								className="alert alert-warning py-2 text-sm"
-								role="alert"
-							>
-								ブラウザの通知が拒否されています。通知 ON の経路でも出発前の通知は送信されません。ブラウザ設定で許可に変更してください。
+							<div className="alert alert-warning py-2 text-sm" role="alert">
+								ブラウザの通知が拒否されています。通知 ON
+								の経路でも出発前の通知は送信されません。ブラウザ設定で許可に変更してください。
 							</div>
 						)}
 						{hasNotifyEnabledRoutes && notifyBeforeMinutes !== undefined && (
@@ -343,10 +373,10 @@ export function RouteRegistration({
 										aria-describedby="notify-before-minutes-unit"
 										value={notifyInputValue}
 										onChange={(e) => {
-											// 確定は blur / Enter で行う（入力中の逐次 persist を防ぐ）
+											// 確定は Enter キー / 設定ボタンで行う（入力中の逐次 persist を防ぐ）。
+											// blur による自動確定は廃止（意図しない確定を避けるため）。
 											setNotifyInputValue(e.target.value);
 										}}
-										onBlur={commitNotifyInput}
 										onKeyDown={(e) => {
 											if (e.key === "Enter") {
 												e.preventDefault();
@@ -360,6 +390,15 @@ export function RouteRegistration({
 									>
 										分前
 									</span>
+									<button
+										type="button"
+										className="btn btn-xs btn-primary"
+										onClick={commitNotifyInput}
+										disabled={!canCommitNotifyInput}
+										aria-label="通知タイミングを設定"
+									>
+										設定
+									</button>
 									{notifyPermission === "default" &&
 										onRequestNotificationPermission && (
 											<button
@@ -400,28 +439,56 @@ export function RouteRegistration({
 													className="toggle toggle-primary toggle-xs"
 													checked={route.notifyEnabled === true}
 													onChange={async () => {
-														setSubmitting(true);
+														// submitting（フォーム送信用）とは別状態で管理し、
+														// 登録/更新ボタンの表示（テキスト・disabled）が通知 ON/OFF で
+														// 乱れないようにする。
+														setTogglingRouteId(route.id);
+														// 「どの経路を切り替えたか」を明示するためバス停名を文言に含める。
+														// 失敗時のトーストでも同じ文脈を提示できるよう先に組み立てる。
+														const fromName =
+															stopNameMap.get(route.fromStopId) ??
+															route.fromStopId;
+														const toName =
+															stopNameMap.get(route.toStopId) ?? route.toStopId;
+														const routeLabel = `${fromName} → ${toName}`;
 														try {
 															// permission が "default" のときに許可プロンプトを促す。
 															// "denied" のときはユーザーの意図だけ保存し、発火側 (useNotification) で抑止する。
 															// permission 要求の rejection もこの try/catch で捕捉するため
 															// ここに入れている（以前は try 外で rejection が未処理になっていた）。
-															if (!route.notifyEnabled && onRequestNotificationPermission) {
+															if (
+																!route.notifyEnabled &&
+																onRequestNotificationPermission
+															) {
 																await onRequestNotificationPermission();
 															}
+															const nextEnabled = !route.notifyEnabled;
 															await onUpdate({
 																...route,
-																notifyEnabled: !route.notifyEnabled,
+																notifyEnabled: nextEnabled,
 															});
+															showToast(
+																nextEnabled
+																	? `${routeLabel} の通知を ON にしました`
+																	: `${routeLabel} の通知を OFF にしました`,
+																{ variant: "success" },
+															);
 														} catch (err) {
-															setErrorMessage(
-																err instanceof Error ? err.message : "通知設定の更新に失敗しました",
+															const detail =
+																err instanceof Error
+																	? err.message
+																	: "通知設定の更新に失敗しました";
+															showToast(
+																`${routeLabel} の通知設定に失敗しました: ${detail}`,
+																{
+																	variant: "error",
+																},
 															);
 														} finally {
-															setSubmitting(false);
+															setTogglingRouteId(null);
 														}
 													}}
-													disabled={submitting}
+													disabled={togglingRouteId === route.id}
 													aria-label="通知の切り替え"
 												/>
 											</td>

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -331,7 +331,7 @@ export function RouteRegistration({
 								type="button"
 								className="btn btn-ghost"
 								onClick={resetForm}
-								disabled={submitting}
+								disabled={submitting || togglingRouteId !== null}
 							>
 								キャンセル
 							</button>
@@ -507,7 +507,7 @@ export function RouteRegistration({
 													type="button"
 													className="btn btn-ghost btn-xs"
 													onClick={() => handleEdit(route)}
-													disabled={submitting}
+													disabled={submitting || togglingRouteId !== null}
 												>
 													編集
 												</button>
@@ -515,7 +515,7 @@ export function RouteRegistration({
 													type="button"
 													className="btn btn-ghost btn-xs text-error"
 													onClick={() => handleDelete(route.id)}
-													disabled={submitting}
+													disabled={submitting || togglingRouteId !== null}
 												>
 													削除
 												</button>

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -126,6 +126,12 @@ export function RouteRegistration({
 			showToast(`通知タイミングを設定できませんでした: ${detail}`, {
 				variant: "error",
 			});
+			// 確定に失敗したのに入力欄だけ新しい値のまま残ると、保存済みの値と
+			// 画面表示が乖離してユーザーの誤解を招く。props の現在値へロールバック
+			// して、表示と永続化値の整合を保つ。
+			if (notifyBeforeMinutes !== undefined) {
+				setNotifyInputValue(String(notifyBeforeMinutes));
+			}
 		}
 	};
 
@@ -488,7 +494,7 @@ export function RouteRegistration({
 															setTogglingRouteId(null);
 														}
 													}}
-													disabled={togglingRouteId === route.id}
+													disabled={togglingRouteId !== null}
 													aria-label="通知の切り替え"
 												/>
 											</td>

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -400,7 +400,11 @@ export function RouteRegistration({
 										type="button"
 										className="btn btn-xs btn-primary"
 										onClick={commitNotifyInput}
-										disabled={!canCommitNotifyInput}
+										disabled={
+											!canCommitNotifyInput ||
+											submitting ||
+											togglingRouteId !== null
+										}
 										aria-label="通知タイミングを設定"
 									>
 										設定
@@ -494,7 +498,7 @@ export function RouteRegistration({
 															setTogglingRouteId(null);
 														}
 													}}
-													disabled={togglingRouteId !== null}
+													disabled={submitting || togglingRouteId !== null}
 													aria-label="通知の切り替え"
 												/>
 											</td>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,50 @@
+import { type Toast, type ToastVariant, useToast } from "../hooks/useToast";
+
+const variantClass: Record<ToastVariant, string> = {
+	success: "alert-success",
+	error: "alert-error",
+	info: "alert-info",
+};
+
+/** 画面右下にトーストを積む表示コンテナ */
+export function ToastContainer() {
+	const { toasts, dismissToast } = useToast();
+	return (
+		<div className="toast toast-end toast-bottom z-50">
+			{toasts.map((toast) => (
+				<ToastItem
+					key={toast.id}
+					toast={toast}
+					onDismiss={() => dismissToast(toast.id)}
+				/>
+			))}
+		</div>
+	);
+}
+
+function ToastItem({
+	toast,
+	onDismiss,
+}: {
+	toast: Toast;
+	onDismiss: () => void;
+}) {
+	const isError = toast.variant === "error";
+	return (
+		<div
+			className={`alert ${variantClass[toast.variant]} shadow-lg`}
+			role={isError ? "alert" : "status"}
+			aria-live={isError ? "assertive" : "polite"}
+		>
+			<span>{toast.message}</span>
+			<button
+				type="button"
+				className="btn btn-ghost btn-xs"
+				aria-label="閉じる"
+				onClick={onDismiss}
+			>
+				×
+			</button>
+		</div>
+	);
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { type Toast, type ToastVariant, useToast } from "../hooks/useToast";
 
 const variantClass: Record<ToastVariant, string> = {
@@ -29,6 +30,15 @@ function ToastItem({
 	toast: Toast;
 	onDismiss: () => void;
 }) {
+	// 自動消去タイマーを ToastItem のライフサイクルに合わせて管理する。
+	// アンマウント・手動消去による再レンダリング時にクリーンアップで
+	// clearTimeout が呼ばれるため、pending タイマーの残留を防ぐ。
+	useEffect(() => {
+		if (toast.durationMs <= 0) return;
+		const timer = setTimeout(onDismiss, toast.durationMs);
+		return () => clearTimeout(timer);
+	}, [toast.durationMs, onDismiss]);
+
 	const isError = toast.variant === "error";
 	return (
 		<div

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -9,35 +9,31 @@ const variantClass: Record<ToastVariant, string> = {
 
 /** 画面右下にトーストを積む表示コンテナ */
 export function ToastContainer() {
-	const { toasts, dismissToast } = useToast();
+	const { toasts } = useToast();
 	return (
 		<div className="toast toast-end toast-bottom z-50">
 			{toasts.map((toast) => (
-				<ToastItem
-					key={toast.id}
-					toast={toast}
-					onDismiss={() => dismissToast(toast.id)}
-				/>
+				<ToastItem key={toast.id} toast={toast} />
 			))}
 		</div>
 	);
 }
 
-function ToastItem({
-	toast,
-	onDismiss,
-}: {
-	toast: Toast;
-	onDismiss: () => void;
-}) {
+function ToastItem({ toast }: { toast: Toast }) {
+	// dismissToast は ToastProvider 側で useCallback により安定参照になっている。
+	// onDismiss をプロップで受けると ToastContainer の再レンダリングごとに
+	// 新しい参照となり useEffect の cleanup→再スケジュールで自動消去タイマーが
+	// リセットされるため、ToastItem 内部で直接取得する。
+	const { dismissToast } = useToast();
+
 	// 自動消去タイマーを ToastItem のライフサイクルに合わせて管理する。
 	// アンマウント・手動消去による再レンダリング時にクリーンアップで
 	// clearTimeout が呼ばれるため、pending タイマーの残留を防ぐ。
 	useEffect(() => {
 		if (toast.durationMs <= 0) return;
-		const timer = setTimeout(onDismiss, toast.durationMs);
+		const timer = setTimeout(() => dismissToast(toast.id), toast.durationMs);
 		return () => clearTimeout(timer);
-	}, [toast.durationMs, onDismiss]);
+	}, [toast.id, toast.durationMs, dismissToast]);
 
 	const isError = toast.variant === "error";
 	return (
@@ -51,7 +47,7 @@ function ToastItem({
 				type="button"
 				className="btn btn-ghost btn-xs"
 				aria-label="閉じる"
-				onClick={onDismiss}
+				onClick={() => dismissToast(toast.id)}
 			>
 				×
 			</button>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -42,7 +42,9 @@ function ToastItem({ toast }: { toast: Toast }) {
 			role={isError ? "alert" : "status"}
 			aria-live={isError ? "assertive" : "polite"}
 		>
-			<span>{toast.message}</span>
+			{/* close ボタンが右端にあるため、メッセージも text-end で右寄せに
+			    揃え視覚的な整列を取る（issue #91）。 */}
+			<span className="flex-1 text-end">{toast.message}</span>
 			<button
 				type="button"
 				className="btn btn-ghost btn-xs"

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -15,8 +15,12 @@ export function useNotificationSettings() {
 
 	const setMinutes = useCallback((value: number) => {
 		const clamped = Math.max(1, Math.min(60, Math.floor(value)));
-		setMinutesState(clamped);
+		// 永続化を先に試行し、成功した場合のみ state を更新する。
+		// localStorage の書き込み失敗時（QuotaExceededError 等）に
+		// 画面表示と保存値が乖離しないようにする。失敗時は throw して
+		// 呼び出し側にエラー通知を委ねる。
 		localStorage.setItem(STORAGE_KEY, String(clamped));
+		setMinutesState(clamped);
 	}, []);
 
 	return { minutes, setMinutes } as const;

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -30,10 +30,19 @@ export function useRoutes(): UseRoutesReturn {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
 	const reloadSeqRef = useRef(0);
+	// 初回ロード完了後は setLoading(true) を呼ばない。
+	// add/update/remove 後の reload で loading が true に戻ると
+	// App.tsx の `{db && !loading && !error && (...)}` ブロックが
+	// 一時的にアンマウントされ、ページのスクロール位置が先頭に戻る
+	// （MapView/DepartureBoard/RouteRegistration が再マウントされる）。
+	// 画面ちらつきとスクロール飛びを防ぐため、リロードは静かに行う。
+	const hasLoadedOnceRef = useRef(false);
 
 	const reload = useCallback(async () => {
 		const seq = ++reloadSeqRef.current;
-		setLoading(true);
+		if (!hasLoadedOnceRef.current) {
+			setLoading(true);
+		}
 		try {
 			const all = await getAllRoutes();
 			const registered = all.filter(
@@ -48,6 +57,7 @@ export function useRoutes(): UseRoutesReturn {
 		} finally {
 			if (seq === reloadSeqRef.current) {
 				setLoading(false);
+				hasLoadedOnceRef.current = true;
 			}
 		}
 	}, []);

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -51,13 +51,16 @@ export function useRoutes(): UseRoutesReturn {
 			if (seq !== reloadSeqRef.current) return;
 			setRoutes(registered);
 			setError(null);
+			// 読み込み成功時のみ「初回ロード済み」フラグを立てる。
+			// finally で立てると初回が失敗しても true になり、以降の再試行で
+			// setLoading(true) が呼ばれず LoadingSpinner が表示されなくなる。
+			hasLoadedOnceRef.current = true;
 		} catch (e) {
 			if (seq !== reloadSeqRef.current) return;
 			setError(e instanceof Error ? e : new Error(String(e)));
 		} finally {
 			if (seq === reloadSeqRef.current) {
 				setLoading(false);
-				hasLoadedOnceRef.current = true;
 			}
 		}
 	}, []);

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,84 @@
+import {
+	type ReactNode,
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+
+/** トーストのビジュアル種別 */
+export type ToastVariant = "success" | "error" | "info";
+
+export type Toast = {
+	/** 一意 ID（dismissToast や React key に使用） */
+	id: number;
+	/** 表示メッセージ */
+	message: string;
+	/** ビジュアル種別 */
+	variant: ToastVariant;
+};
+
+type ShowToastOptions = {
+	variant?: ToastVariant;
+	/** 自動消去までのミリ秒（デフォルト 3000ms） */
+	durationMs?: number;
+};
+
+type ToastContextValue = {
+	toasts: Toast[];
+	showToast: (message: string, options?: ShowToastOptions) => void;
+	dismissToast: (id: number) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION_MS = 3000;
+
+/**
+ * トースト通知のプロバイダ。
+ * 配下の useToast 呼び出しに対して toasts 配列と操作関数を提供する。
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+	const nextIdRef = useRef(1);
+
+	const dismissToast = useCallback((id: number) => {
+		setToasts((prev) => prev.filter((t) => t.id !== id));
+	}, []);
+
+	const showToast = useCallback(
+		(message: string, options?: ShowToastOptions) => {
+			const id = nextIdRef.current;
+			nextIdRef.current += 1;
+			const variant = options?.variant ?? "success";
+			const durationMs = options?.durationMs ?? DEFAULT_DURATION_MS;
+			setToasts((prev) => [...prev, { id, message, variant }]);
+			if (durationMs > 0) {
+				setTimeout(() => {
+					setToasts((prev) => prev.filter((t) => t.id !== id));
+				}, durationMs);
+			}
+		},
+		[],
+	);
+
+	const value = useMemo(
+		() => ({ toasts, showToast, dismissToast }),
+		[toasts, showToast, dismissToast],
+	);
+
+	return (
+		<ToastContext.Provider value={value}>{children}</ToastContext.Provider>
+	);
+}
+
+/** トースト操作フック（ToastProvider 配下でのみ使用可能） */
+export function useToast(): ToastContextValue {
+	const ctx = useContext(ToastContext);
+	if (ctx == null) {
+		throw new Error("useToast must be used within ToastProvider");
+	}
+	return ctx;
+}

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -18,6 +18,11 @@ export type Toast = {
 	message: string;
 	/** ビジュアル種別 */
 	variant: ToastVariant;
+	/**
+	 * 自動消去までのミリ秒。0 の場合は自動消去しない。
+	 * ToastItem 側の useEffect がこの値を元にタイマーを管理する。
+	 */
+	durationMs: number;
 };
 
 type ShowToastOptions = {
@@ -39,6 +44,10 @@ const DEFAULT_DURATION_MS = 3000;
 /**
  * トースト通知のプロバイダ。
  * 配下の useToast 呼び出しに対して toasts 配列と操作関数を提供する。
+ *
+ * 自動消去タイマーはここではスケジュールせず、各 ToastItem の
+ * useEffect に委譲する。アンマウント時・手動消去時のクリーンアップを
+ * コンポーネントライフサイクルに合わせて行うため。
  */
 export function ToastProvider({ children }: { children: ReactNode }) {
 	const [toasts, setToasts] = useState<Toast[]>([]);
@@ -54,12 +63,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 			nextIdRef.current += 1;
 			const variant = options?.variant ?? "success";
 			const durationMs = options?.durationMs ?? DEFAULT_DURATION_MS;
-			setToasts((prev) => [...prev, { id, message, variant }]);
-			if (durationMs > 0) {
-				setTimeout(() => {
-					setToasts((prev) => prev.filter((t) => t.id !== id));
-				}, durationMs);
-			}
+			setToasts((prev) => [...prev, { id, message, variant, durationMs }]);
 		},
 		[],
 	);

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1,5 +1,11 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render as rtlRender,
+	screen,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import initSqlJs from "sql.js";
 import {
 	afterEach,
@@ -11,9 +17,24 @@ import {
 	vi,
 } from "vitest";
 import { RouteRegistration } from "../src/components/RouteRegistration";
+import { ToastContainer } from "../src/components/Toast";
+import { ToastProvider } from "../src/hooks/useToast";
 import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
 import type { GtfsData } from "../src/types/gtfs";
 import type { RegisteredRouteEntry } from "../src/types/route-entry";
+
+/**
+ * ToastProvider + ToastContainer を含めてレンダリングするヘルパ。
+ * RouteRegistration は useToast を使うため ToastProvider 下での描画が必須。
+ */
+function render(ui: ReactElement) {
+	return rtlRender(
+		<ToastProvider>
+			<ToastContainer />
+			{ui}
+		</ToastProvider>,
+	);
+}
 
 const testStops: GtfsData["stops"] = [
 	{
@@ -300,6 +321,199 @@ describe("RouteRegistration コンポーネント", () => {
 		});
 	});
 
+	it("トグル ON 成功時に「通知を ON にしました」トーストが表示される", async () => {
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={vi.fn().mockResolvedValue(undefined)}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		expect(await screen.findByText(/通知を ON にしました/)).toBeInTheDocument();
+	});
+
+	it("トグル OFF 成功時に「通知を OFF にしました」トーストが表示される", async () => {
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: true,
+			},
+		];
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={vi.fn().mockResolvedValue(undefined)}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		expect(
+			await screen.findByText(/通知を OFF にしました/),
+		).toBeInTheDocument();
+	});
+
+	it("トグル処理中でも経路登録ボタンの表示（テキスト・disabled）は変わらない", async () => {
+		// 通知の ON/OFF をするたびに登録ボタンが「保存中...」になったり disabled になったり
+		// 揺れる問題を回避する。トグル操作はフォーム送信と独立した状態で管理すべき。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		// onUpdate を保留させてトグル処理中の状態を観測する
+		let resolveUpdate: () => void = () => {};
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		const submitButton = screen.getByRole("button", { name: "登録" });
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		// トグル処理が保留中でも登録ボタンは「登録」のままで enabled
+		expect(submitButton).toHaveTextContent("登録");
+		expect(submitButton).not.toBeDisabled();
+
+		resolveUpdate();
+	});
+
+	it("トグル ON 成功時のトーストに乗車バス停名・降車バス停名が含まれる", async () => {
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={vi.fn().mockResolvedValue(undefined)}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		// どの経路のトグルを切り替えたのか明示するため、乗車/降車のバス停名を文言に含める
+		expect(
+			await screen.findByText(
+				/旭川駅前[\s\S]*市役所前[\s\S]*通知を\s*ON\s*にしました/,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("トグル OFF 成功時のトーストに乗車バス停名・降車バス停名が含まれる", async () => {
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: true,
+			},
+		];
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={vi.fn().mockResolvedValue(undefined)}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		expect(
+			await screen.findByText(
+				/旭川駅前[\s\S]*市役所前[\s\S]*通知を\s*OFF\s*にしました/,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("トグル操作で onUpdate が reject したときエラートーストが表示される", async () => {
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		const onUpdate = vi
+			.fn()
+			.mockRejectedValue(new Error("IndexedDB 書き込みに失敗"));
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		expect(
+			await screen.findByText(/IndexedDB 書き込みに失敗/),
+		).toBeInTheDocument();
+	});
+
 	it("permission が denied でもトグルは機能しユーザーの意図を保存する", async () => {
 		const routes: RegisteredRouteEntry[] = [
 			{
@@ -365,15 +579,11 @@ describe("RouteRegistration コンポーネント", () => {
 		);
 
 		expect(
-			screen.getByText(
-				/ブラウザの通知が拒否されています/,
-			),
+			screen.getByText(/ブラウザの通知が拒否されています/),
 		).toBeInTheDocument();
 		// 本 PR で「発車」→「出発」に用語統一したため、警告文言も整合していることを確認する
 		expect(
-			screen.getByText(
-				/出発前の通知は送信されません/,
-			),
+			screen.getByText(/出発前の通知は送信されません/),
 		).toBeInTheDocument();
 	});
 
@@ -447,9 +657,12 @@ describe("RouteRegistration コンポーネント", () => {
 		const toggle = screen.getByRole("checkbox", { name: "通知の切り替え" });
 		await userEvent.click(toggle);
 
-		// エラーメッセージが表示される（rejection が catch で捕捉された証左）
+		// エラートーストが表示される（rejection が catch で捕捉された証左）。
+		// トースト文言にはどの経路で失敗したか明示するためバス停名と原因が含まれる。
 		expect(
-			await screen.findByText("permission 要求に失敗しました"),
+			await screen.findByText(
+				/旭川駅前[\s\S]*市役所前[\s\S]*permission 要求に失敗しました/,
+			),
 		).toBeInTheDocument();
 		// permission 要求段階で失敗したため onUpdate は呼ばれない
 		expect(onUpdate).not.toHaveBeenCalled();
@@ -518,7 +731,9 @@ describe("RouteRegistration コンポーネント", () => {
 					notifyBeforeMinutes={5}
 				/>,
 			);
-			expect(screen.getByText(/現在、出発\s*5\s*分前に通知します/)).toBeInTheDocument();
+			expect(
+				screen.getByText(/現在、出発\s*5\s*分前に通知します/),
+			).toBeInTheDocument();
 		});
 
 		it("hasNotifyEnabledRoutes=true のとき変更用の入力が表示される", () => {
@@ -556,7 +771,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("hasNotifyEnabledRoutes=false のとき通知タイミング UI は表示されない", () => {
 			const routes: RegisteredRouteEntry[] = [
-				{ id: 1, fromStopId: "test:S001", toStopId: "test:S002", walkMinutes: 5 },
+				{
+					id: 1,
+					fromStopId: "test:S001",
+					toStopId: "test:S002",
+					walkMinutes: 5,
+				},
 			];
 			render(
 				<RouteRegistration
@@ -594,7 +814,25 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeInTheDocument();
 		});
 
-		it("blur で有効値が onNotifyBeforeMinutesChange に渡る", () => {
+		it("設定ボタンが表示される", () => {
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			expect(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			).toBeInTheDocument();
+		});
+
+		it("値を変更して設定ボタンを押すと onNotifyBeforeMinutesChange が呼ばれる", async () => {
 			const onChange = vi.fn();
 			render(
 				<RouteRegistration
@@ -610,12 +848,37 @@ describe("RouteRegistration コンポーネント", () => {
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "15" } });
-			fireEvent.blur(input);
+			await userEvent.click(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			);
 			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenCalledWith(15);
 		});
 
-		it("Enter キーで有効値が onNotifyBeforeMinutesChange に渡る", () => {
+		it("設定ボタン押下で成功トーストが表示される", async () => {
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			await userEvent.click(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			);
+			expect(
+				await screen.findByText(/通知タイミングを\s*15\s*分前に設定しました/),
+			).toBeInTheDocument();
+		});
+
+		it("Enter キー押下でも onNotifyBeforeMinutesChange が呼ばれ成功トーストが表示される", async () => {
 			const onChange = vi.fn();
 			render(
 				<RouteRegistration
@@ -634,9 +897,32 @@ describe("RouteRegistration コンポーネント", () => {
 			fireEvent.keyDown(input, { key: "Enter" });
 			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenCalledWith(20);
+			expect(
+				await screen.findByText(/通知タイミングを\s*20\s*分前に設定しました/),
+			).toBeInTheDocument();
 		});
 
-		it("onChange 単体では onNotifyBeforeMinutesChange が呼ばれない", () => {
+		it("blur では onNotifyBeforeMinutesChange が呼ばれない（確定は Enter / 設定ボタンのみ）", () => {
+			const onChange = vi.fn();
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={onChange}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			fireEvent.blur(input);
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it("入力を変更しただけでは onNotifyBeforeMinutesChange は呼ばれない", () => {
 			const onChange = vi.fn();
 			render(
 				<RouteRegistration
@@ -656,8 +942,7 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(onChange).not.toHaveBeenCalled();
 		});
 
-		it("blur で 60 を超える値は反映されず表示が直前値に戻る", () => {
-			const onChange = vi.fn();
+		it("現在値と同じ値では設定ボタンが無効化される", () => {
 			render(
 				<RouteRegistration
 					db={db}
@@ -667,18 +952,36 @@ describe("RouteRegistration コンポーネント", () => {
 					onDelete={vi.fn().mockResolvedValue(undefined)}
 					hasNotifyEnabledRoutes={true}
 					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			// 初期値が 5 で入力値も 5 のまま
+			expect(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			).toBeDisabled();
+		});
+
+		it("範囲外の値（60 超）では設定ボタンが無効化される", () => {
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "100" } });
-			fireEvent.blur(input);
-			expect(onChange).not.toHaveBeenCalled();
-			expect(input).toHaveValue(5);
+			expect(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			).toBeDisabled();
 		});
 
-		it("blur で小数は反映されず表示が直前値に戻る", () => {
-			const onChange = vi.fn();
+		it("小数値では設定ボタンが無効化される", () => {
 			render(
 				<RouteRegistration
 					db={db}
@@ -688,18 +991,40 @@ describe("RouteRegistration コンポーネント", () => {
 					onDelete={vi.fn().mockResolvedValue(undefined)}
 					hasNotifyEnabledRoutes={true}
 					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					onNotifyBeforeMinutesChange={vi.fn()}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "5.5" } });
-			fireEvent.blur(input);
-			expect(onChange).not.toHaveBeenCalled();
-			expect(input).toHaveValue(5);
+			expect(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			).toBeDisabled();
 		});
 
-		it("blur で空値は反映されず表示が直前値に戻る", () => {
-			const onChange = vi.fn();
+		it("空値では設定ボタンが無効化される", () => {
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "" } });
+			expect(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			).toBeDisabled();
+		});
+
+		it("onNotifyBeforeMinutesChange が throw した場合はエラートーストが表示される", async () => {
+			const onChange = vi.fn().mockImplementation(() => {
+				throw new Error("localStorage 書き込みに失敗しました");
+			});
 			render(
 				<RouteRegistration
 					db={db}
@@ -713,10 +1038,14 @@ describe("RouteRegistration コンポーネント", () => {
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
-			fireEvent.change(input, { target: { value: "" } });
-			fireEvent.blur(input);
-			expect(onChange).not.toHaveBeenCalled();
-			expect(input).toHaveValue(5);
+			fireEvent.change(input, { target: { value: "15" } });
+			await userEvent.click(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			);
+			// エラートースト文言は実装依存だが「設定できませんでした」は確実に含める
+			expect(
+				await screen.findByText(/通知タイミング.*設定できませんでした/),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -377,6 +377,49 @@ describe("RouteRegistration コンポーネント", () => {
 		).toBeInTheDocument();
 	});
 
+	it("フォーム送信中（submitting=true 相当）は通知トグルも disabled になる", async () => {
+		// フォーム送信（登録/更新/削除）と通知トグルの onUpdate が同時進行すると
+		// 編集モード中の同一経路で race が発生し得るため、submitting 中はトグルも
+		// 排他的に無効化する。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		// 削除ボタンを押して onDelete を保留させると submitting=true の状態を作れる
+		let resolveDelete: () => void = () => {};
+		const onDelete = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveDelete = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={vi.fn().mockResolvedValue(undefined)}
+				onDelete={onDelete}
+			/>,
+		);
+
+		const toggle = screen.getByRole("checkbox", { name: "通知の切り替え" });
+		expect(toggle).not.toBeDisabled();
+
+		// 削除をクリック（onDelete は保留 → submitting=true のまま）
+		await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+		// submitting 中はトグルも disabled になる
+		expect(toggle).toBeDisabled();
+
+		resolveDelete();
+	});
+
 	it("トグル処理中は他の経路のトグルも disabled になる（重複サブミッション防止）", async () => {
 		// 経路 A 処理中に経路 B をクリックすると togglingRouteId が B で上書きされ
 		// A のトグルが処理中に再有効化される問題を防ぐため、処理中は全トグルを
@@ -1098,6 +1141,79 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(
 				await screen.findByText(/通知タイミング.*設定できませんでした/),
 			).toBeInTheDocument();
+		});
+
+		it("フォーム送信中（submitting=true 相当）は設定ボタンが disabled になる", async () => {
+			// 通知タイミング確定と他の非同期処理（フォーム送信・トグル）が同時進行すると
+			// UI フィードバックに齟齬が出るため、submitting 中は設定ボタンも無効化する。
+			let resolveDelete: () => void = () => {};
+			const onDelete = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveDelete = r;
+					}),
+			);
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={onDelete}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			// 入力値を変更して canCommitNotifyInput=true にしておく
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			const setButton = screen.getByRole("button", {
+				name: "通知タイミングを設定",
+			});
+			expect(setButton).not.toBeDisabled();
+
+			// 削除をクリックして submitting=true の状態を作る
+			await userEvent.click(screen.getByRole("button", { name: "削除" }));
+			expect(setButton).toBeDisabled();
+
+			resolveDelete();
+		});
+
+		it("トグル処理中（togglingRouteId !== null）は設定ボタンが disabled になる", async () => {
+			let resolveUpdate: () => void = () => {};
+			const onUpdate = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveUpdate = r;
+					}),
+			);
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={onUpdate}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={vi.fn()}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			const setButton = screen.getByRole("button", {
+				name: "通知タイミングを設定",
+			});
+			expect(setButton).not.toBeDisabled();
+
+			// トグルをクリックして togglingRouteId !== null の状態を作る
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: "通知の切り替え" }),
+			);
+			expect(setButton).toBeDisabled();
+
+			resolveUpdate();
 		});
 
 		it("onNotifyBeforeMinutesChange が throw したら入力欄の表示が元の値に戻る", async () => {

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -377,6 +377,128 @@ describe("RouteRegistration コンポーネント", () => {
 		).toBeInTheDocument();
 	});
 
+	it("トグル処理中は同一経路の編集ボタンが disabled になる（race 防止）", async () => {
+		// 同一経路のトグル onUpdate と編集フォーム submit の onUpdate が race して
+		// stale な notifyEnabled で上書きされる可能性があるため、トグル処理中は
+		// 編集ボタンも無効化する。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		let resolveUpdate: () => void = () => {};
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		const editButton = screen.getByRole("button", { name: "編集" });
+		expect(editButton).not.toBeDisabled();
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+		expect(editButton).toBeDisabled();
+
+		resolveUpdate();
+	});
+
+	it("トグル処理中は同一経路の削除ボタンが disabled になる（race 防止）", async () => {
+		// 同一経路のトグル onUpdate と onDelete が concurrent 発火する race を防ぐ。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		let resolveUpdate: () => void = () => {};
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		const deleteButton = screen.getByRole("button", { name: "削除" });
+		expect(deleteButton).not.toBeDisabled();
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+		expect(deleteButton).toBeDisabled();
+
+		resolveUpdate();
+	});
+
+	it("トグル処理中はキャンセルボタンも disabled になる（編集モード中）", async () => {
+		// 編集モード中にトグル処理が走ると、キャンセル操作で編集を抜けられると
+		// トグル対象の state が途中で失われる。状態の一貫性のため無効化する。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+		];
+		let resolveUpdate: () => void = () => {};
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		// 編集モードへ遷移
+		await userEvent.click(screen.getByRole("button", { name: "編集" }));
+		const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+		expect(cancelButton).not.toBeDisabled();
+
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+		expect(cancelButton).toBeDisabled();
+
+		resolveUpdate();
+	});
+
 	it("フォーム送信中（submitting=true 相当）は通知トグルも disabled になる", async () => {
 		// フォーム送信（登録/更新/削除）と通知トグルの onUpdate が同時進行すると
 		// 編集モード中の同一経路で race が発生し得るため、submitting 中はトグルも

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -377,6 +377,58 @@ describe("RouteRegistration コンポーネント", () => {
 		).toBeInTheDocument();
 	});
 
+	it("トグル処理中は他の経路のトグルも disabled になる（重複サブミッション防止）", async () => {
+		// 経路 A 処理中に経路 B をクリックすると togglingRouteId が B で上書きされ
+		// A のトグルが処理中に再有効化される問題を防ぐため、処理中は全トグルを
+		// 排他無効化する。
+		const routes: RegisteredRouteEntry[] = [
+			{
+				id: 1,
+				fromStopId: "test:S001",
+				toStopId: "test:S002",
+				walkMinutes: 5,
+				notifyEnabled: false,
+			},
+			{
+				id: 2,
+				fromStopId: "test:S002",
+				toStopId: "test:S003",
+				walkMinutes: 7,
+				notifyEnabled: false,
+			},
+		];
+		let resolveUpdate: () => void = () => {};
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={vi.fn().mockResolvedValue(1)}
+				onUpdate={onUpdate}
+				onDelete={vi.fn().mockResolvedValue(undefined)}
+			/>,
+		);
+
+		const toggles = screen.getAllByRole("checkbox", {
+			name: "通知の切り替え",
+		});
+		expect(toggles).toHaveLength(2);
+
+		// 経路 A のトグルをクリック（onUpdate は保留）
+		await userEvent.click(toggles[0]);
+
+		// 経路 A だけでなく経路 B のトグルも disabled になっている
+		expect(toggles[0]).toBeDisabled();
+		expect(toggles[1]).toBeDisabled();
+
+		resolveUpdate();
+	});
+
 	it("トグル処理中でも経路登録ボタンの表示（テキスト・disabled）は変わらない", async () => {
 		// 通知の ON/OFF をするたびに登録ボタンが「保存中...」になったり disabled になったり
 		// 揺れる問題を回避する。トグル操作はフォーム送信と独立した状態で管理すべき。
@@ -1046,6 +1098,38 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(
 				await screen.findByText(/通知タイミング.*設定できませんでした/),
 			).toBeInTheDocument();
+		});
+
+		it("onNotifyBeforeMinutesChange が throw したら入力欄の表示が元の値に戻る", async () => {
+			// 設定確定に失敗したのに入力欄だけ新しい値のまま残ると、
+			// 保存されている値と画面表示が乖離してユーザーの誤解を招く。
+			// 失敗時は確定直前の値（props の notifyBeforeMinutes）へロールバックする。
+			const onChange = vi.fn().mockImplementation(() => {
+				throw new Error("localStorage 書き込みに失敗しました");
+			});
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					onNotifyBeforeMinutesChange={onChange}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			expect(input).toHaveValue(15);
+			await userEvent.click(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			);
+			// エラートーストが出た上で、入力値は元の 5 にロールバックされている
+			expect(
+				await screen.findByText(/通知タイミング.*設定できませんでした/),
+			).toBeInTheDocument();
+			expect(input).toHaveValue(5);
 		});
 	});
 

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1091,7 +1091,9 @@ describe("RouteRegistration コンポーネント", () => {
 				screen.getByRole("button", { name: "通知タイミングを設定" }),
 			);
 			expect(
-				await screen.findByText(/通知タイミングを\s*15\s*分前に設定しました/),
+				await screen.findByText(
+					/発車の\s*15\s*分前に通知するように設定しました/,
+				),
 			).toBeInTheDocument();
 		});
 
@@ -1115,8 +1117,41 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenCalledWith(20);
 			expect(
-				await screen.findByText(/通知タイミングを\s*20\s*分前に設定しました/),
+				await screen.findByText(
+					/発車の\s*20\s*分前に通知するように設定しました/,
+				),
 			).toBeInTheDocument();
+		});
+
+		it("onNotifyBeforeMinutesChange が未指定の場合は成功トーストが表示されない", async () => {
+			// optional chaining で silently no-op するだけでは、コールバック未指定時に
+			// 「設定しました」トーストが誤って表示され、ユーザーに未実施の操作が
+			// 完了したかのような誤情報を伝えてしまう。コールバックが実際に呼ばれた
+			// 場合のみ成功トーストを出すべき。
+			render(
+				<RouteRegistration
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					notifyBeforeMinutes={5}
+					// onNotifyBeforeMinutesChange を意図的に渡さない
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+			await userEvent.click(
+				screen.getByRole("button", { name: "通知タイミングを設定" }),
+			);
+			// 成功トーストが出てはならない
+			expect(
+				screen.queryByText(/発車の\s*15\s*分前に通知するように設定しました/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/通知タイミングを\s*15\s*分前に設定しました/),
+			).not.toBeInTheDocument();
 		});
 
 		it("blur では onNotifyBeforeMinutesChange が呼ばれない（確定は Enter / 設定ボタンのみ）", () => {

--- a/test/Toast.test.tsx
+++ b/test/Toast.test.tsx
@@ -114,6 +114,47 @@ describe("ToastContainer", () => {
 		expect(vi.getTimerCount()).toBe(0);
 	});
 
+	it("複数トースト追加時に既存トーストの自動消去タイマーがリセットされない", () => {
+		// ToastContainer の再レンダリング（2 つ目のトースト追加等）で
+		// ToastItem に渡る onDismiss の参照が変わると、useEffect の依存変化で
+		// cleanup→再スケジュールが走り durationMs が最初からやり直しになる。
+		// その結果、後からトーストが追加されるたび既存トーストが消えなくなる。
+		function DualTrigger() {
+			const { showToast } = useToast();
+			useEffect(() => {
+				showToast("先に出したトースト", { durationMs: 1000 });
+				// 500ms 後に 2 つ目を追加して ToastContainer を再レンダリングさせる
+				const t = setTimeout(() => {
+					showToast("後から出したトースト", { durationMs: 5000 });
+				}, 500);
+				return () => clearTimeout(t);
+			}, [showToast]);
+			return null;
+		}
+
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<DualTrigger />
+			</ToastProvider>,
+		);
+		expect(screen.getByText("先に出したトースト")).toBeInTheDocument();
+
+		// 500ms 経過 → 2 つ目のトーストが追加され再レンダリング
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(screen.getByText("後から出したトースト")).toBeInTheDocument();
+		// 先のトーストはまだ残り 500ms なので表示されている
+		expect(screen.getByText("先に出したトースト")).toBeInTheDocument();
+
+		// さらに 500ms（累計 1000ms）進めると、先のトーストは本来消えているはず
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(screen.queryByText("先に出したトースト")).not.toBeInTheDocument();
+	});
+
 	it("閉じるボタンをクリックするとトーストが消える", async () => {
 		const { default: userEvent } = await import("@testing-library/user-event");
 		const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/test/Toast.test.tsx
+++ b/test/Toast.test.tsx
@@ -94,6 +94,26 @@ describe("ToastContainer", () => {
 		expect(toast?.className).toMatch(/alert-success/);
 	});
 
+	it("ToastContainer アンマウント時に pending タイマーがクリアされる", () => {
+		// 自動消去用 setTimeout が ToastProvider レベルで発火すると、
+		// アンマウントされてもタイマーが残り続けメモリリーク・scheduling 累積の
+		// 原因になる。ToastItem の useEffect 内でスケジュールし、クリーンアップで
+		// clearTimeout するよう実装されている必要がある。
+		const { unmount } = render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="クリア対象" durationMs={5000} />
+			</ToastProvider>,
+		);
+		expect(screen.getByText("クリア対象")).toBeInTheDocument();
+		// durationMs=5000 のタイマーが少なくとも 1 件スケジュールされている
+		expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+		unmount();
+		// アンマウント後は pending タイマーが残っていない
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
 	it("閉じるボタンをクリックするとトーストが消える", async () => {
 		const { default: userEvent } = await import("@testing-library/user-event");
 		const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/test/Toast.test.tsx
+++ b/test/Toast.test.tsx
@@ -69,6 +69,19 @@ describe("ToastContainer", () => {
 		expect(screen.queryByText("消えるメッセージ")).not.toBeInTheDocument();
 	});
 
+	it("メッセージのテキストが右寄せで表示される", () => {
+		// 閉じるボタンが右側にあるため、メッセージ文字列も右寄せにして
+		// 視覚的な整列を取りたい（issue #91）。
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="右寄せテスト" />
+			</ToastProvider>,
+		);
+		const message = screen.getByText("右寄せテスト");
+		expect(message.className).toMatch(/text-end/);
+	});
+
 	it("variant=error のトーストに alert-error クラスが付与される", () => {
 		render(
 			<ToastProvider>

--- a/test/Toast.test.tsx
+++ b/test/Toast.test.tsx
@@ -1,0 +1,112 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastContainer } from "../src/components/Toast";
+import { ToastProvider, useToast } from "../src/hooks/useToast";
+
+/** テスト用のトリガコンポーネント：マウント時に showToast を呼ぶ */
+function Trigger({
+	message,
+	variant,
+	durationMs,
+}: {
+	message: string;
+	variant?: "success" | "error" | "info";
+	durationMs?: number;
+}) {
+	const { showToast } = useToast();
+	useEffect(() => {
+		showToast(message, { variant, durationMs });
+	}, [showToast, message, variant, durationMs]);
+	return null;
+}
+
+describe("ToastContainer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it("showToast されたメッセージが画面に表示される", () => {
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="設定を保存しました" />
+			</ToastProvider>,
+		);
+
+		expect(screen.getByText("設定を保存しました")).toBeInTheDocument();
+	});
+
+	it("表示されたトーストは role=status でアナウンスされる", () => {
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="設定を保存しました" />
+			</ToastProvider>,
+		);
+
+		const status = screen.getByRole("status");
+		expect(status).toHaveTextContent("設定を保存しました");
+	});
+
+	it("durationMs 経過後にトーストが DOM から消える", () => {
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="消えるメッセージ" durationMs={1000} />
+			</ToastProvider>,
+		);
+		expect(screen.getByText("消えるメッセージ")).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(screen.queryByText("消えるメッセージ")).not.toBeInTheDocument();
+	});
+
+	it("variant=error のトーストに alert-error クラスが付与される", () => {
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="保存に失敗しました" variant="error" />
+			</ToastProvider>,
+		);
+
+		const toast = screen.getByText("保存に失敗しました").closest("[role]");
+		expect(toast).not.toBeNull();
+		expect(toast?.className).toMatch(/alert-error/);
+	});
+
+	it("variant=success のトーストに alert-success クラスが付与される", () => {
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="保存しました" variant="success" />
+			</ToastProvider>,
+		);
+
+		const toast = screen.getByText("保存しました").closest("[role]");
+		expect(toast?.className).toMatch(/alert-success/);
+	});
+
+	it("閉じるボタンをクリックするとトーストが消える", async () => {
+		const { default: userEvent } = await import("@testing-library/user-event");
+		const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+		render(
+			<ToastProvider>
+				<ToastContainer />
+				<Trigger message="閉じられる" durationMs={0} />
+			</ToastProvider>,
+		);
+		expect(screen.getByText("閉じられる")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "閉じる" }));
+		expect(screen.queryByText("閉じられる")).not.toBeInTheDocument();
+	});
+});

--- a/test/useNotificationSettings.test.ts
+++ b/test/useNotificationSettings.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNotificationSettings } from "../src/hooks/useNotificationSettings";
 
 const STORAGE_KEY = "notify-before-minutes";
@@ -55,5 +55,27 @@ describe("useNotificationSettings", () => {
 			result.current.setMinutes(-5);
 		});
 		expect(result.current.minutes).toBe(1);
+	});
+
+	it("localStorage.setItem が例外を投げた場合 setMinutes も throw し、state は変更されない", () => {
+		const { result } = renderHook(() => useNotificationSettings());
+		const initial = result.current.minutes;
+		const setItemSpy = vi
+			.spyOn(Storage.prototype, "setItem")
+			.mockImplementation(() => {
+				throw new DOMException("quota exceeded", "QuotaExceededError");
+			});
+
+		try {
+			expect(() => {
+				act(() => {
+					result.current.setMinutes(30);
+				});
+			}).toThrow(/quota exceeded/);
+			// state は永続化失敗時に変更されないこと（画面表示と保存済み値の整合を維持）
+			expect(result.current.minutes).toBe(initial);
+		} finally {
+			setItemSpy.mockRestore();
+		}
 	});
 });

--- a/test/useRoutes.test.ts
+++ b/test/useRoutes.test.ts
@@ -135,38 +135,43 @@ describe("useRoutes", () => {
 					}),
 			);
 
-		const { result } = renderHook(() => useRoutes());
+		try {
+			const { result } = renderHook(() => useRoutes());
 
-		// 初回ロードの失敗が反映されるまで待つ
-		await waitFor(() => {
-			expect(result.current.error).not.toBeNull();
-		});
-		await waitFor(() => {
+			// 初回ロードの失敗が反映されるまで待つ
+			await waitFor(() => {
+				expect(result.current.error).not.toBeNull();
+			});
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			// reload を開始する（await しない。2 回目のコールは pending のまま）
+			let reloadPromise: Promise<void> = Promise.resolve();
+			act(() => {
+				reloadPromise = result.current.reload();
+			});
+
+			// 2 回目の getAllRoutes が解決する前に loading=true になる必要がある
+			await waitFor(() => {
+				expect(result.current.loading).toBe(true);
+			});
+
+			// 2 回目の呼び出しを解決して reload を完了させる
+			resolveSecondCall([]);
+			await act(async () => {
+				await reloadPromise;
+			});
+
+			// 成功後 loading=false に戻り、error もクリアされる
 			expect(result.current.loading).toBe(false);
-		});
-
-		// reload を開始する（await しない。2 回目のコールは pending のまま）
-		let reloadPromise: Promise<void> = Promise.resolve();
-		act(() => {
-			reloadPromise = result.current.reload();
-		});
-
-		// 2 回目の getAllRoutes が解決する前に loading=true になる必要がある
-		await waitFor(() => {
-			expect(result.current.loading).toBe(true);
-		});
-
-		// 2 回目の呼び出しを解決して reload を完了させる
-		resolveSecondCall([]);
-		await act(async () => {
-			await reloadPromise;
-		});
-
-		// 成功後 loading=false に戻り、error もクリアされる
-		expect(result.current.loading).toBe(false);
-		expect(result.current.error).toBeNull();
-
-		getAllRoutesSpy.mockRestore();
+			expect(result.current.error).toBeNull();
+		} finally {
+			// 途中の assertion/waitFor が throw した場合でも spy を確実に復元する。
+			// 復元されないと後続テスト（real getAllRoutes を使うもの）が漏れた
+			// mock に引きずられて不安定化する。
+			getAllRoutesSpy.mockRestore();
+		}
 	});
 
 	it("remove で経路を削除し一覧から消える", async () => {

--- a/test/useRoutes.test.ts
+++ b/test/useRoutes.test.ts
@@ -1,8 +1,10 @@
 import "fake-indexeddb/auto";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRoutes } from "../src/hooks/useRoutes";
+import * as routeStore from "../src/lib/route-store";
 import { addRoute } from "../src/lib/route-store";
+import type { RouteEntry } from "../src/types/route-entry";
 
 beforeEach(() => {
 	globalThis.indexedDB = new IDBFactory();
@@ -116,6 +118,55 @@ describe("useRoutes", () => {
 		// 初回ロード完了後のどの render でも loading が true に戻っていない
 		const afterFirstLoad = loadingHistory.slice(firstFalseIndex);
 		expect(afterFirstLoad.some((v) => v === true)).toBe(false);
+	});
+
+	it("初回ロード失敗後の reload では loading=true が再度設定される", async () => {
+		// 初回 getAllRoutes を失敗させると hasLoadedOnceRef が誤って true に
+		// 設定されるバグがあり、その後の reload で setLoading(true) が呼ばれない。
+		// LoadingSpinner が表示されずユーザーへのフィードバックが欠落する。
+		let resolveSecondCall: (value: RouteEntry[]) => void = () => {};
+		const getAllRoutesSpy = vi
+			.spyOn(routeStore, "getAllRoutes")
+			.mockRejectedValueOnce(new Error("初回 IndexedDB アクセス失敗"))
+			.mockImplementationOnce(
+				() =>
+					new Promise((r) => {
+						resolveSecondCall = r;
+					}),
+			);
+
+		const { result } = renderHook(() => useRoutes());
+
+		// 初回ロードの失敗が反映されるまで待つ
+		await waitFor(() => {
+			expect(result.current.error).not.toBeNull();
+		});
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+		});
+
+		// reload を開始する（await しない。2 回目のコールは pending のまま）
+		let reloadPromise: Promise<void> = Promise.resolve();
+		act(() => {
+			reloadPromise = result.current.reload();
+		});
+
+		// 2 回目の getAllRoutes が解決する前に loading=true になる必要がある
+		await waitFor(() => {
+			expect(result.current.loading).toBe(true);
+		});
+
+		// 2 回目の呼び出しを解決して reload を完了させる
+		resolveSecondCall([]);
+		await act(async () => {
+			await reloadPromise;
+		});
+
+		// 成功後 loading=false に戻り、error もクリアされる
+		expect(result.current.loading).toBe(false);
+		expect(result.current.error).toBeNull();
+
+		getAllRoutesSpy.mockRestore();
 	});
 
 	it("remove で経路を削除し一覧から消える", async () => {

--- a/test/useToast.test.tsx
+++ b/test/useToast.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, useToast } from "../src/hooks/useToast";
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <ToastProvider>{children}</ToastProvider>;
+}
+
+describe("useToast", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("showToast で新しいトーストが toasts に追加される", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.showToast("保存しました", { variant: "success" });
+		});
+
+		expect(result.current.toasts).toHaveLength(1);
+		expect(result.current.toasts[0].message).toBe("保存しました");
+		expect(result.current.toasts[0].variant).toBe("success");
+	});
+
+	it("variant 未指定時はデフォルト success になる", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.showToast("デフォルト");
+		});
+
+		expect(result.current.toasts[0].variant).toBe("success");
+	});
+
+	it("durationMs 経過後にトーストが自動消去される", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.showToast("消えるメッセージ", { durationMs: 1000 });
+		});
+		expect(result.current.toasts).toHaveLength(1);
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(result.current.toasts).toHaveLength(0);
+	});
+
+	it("同時に複数のトーストを追加できる", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.showToast("1 つ目");
+			result.current.showToast("2 つ目", { variant: "error" });
+		});
+
+		expect(result.current.toasts).toHaveLength(2);
+		expect(result.current.toasts[0].message).toBe("1 つ目");
+		expect(result.current.toasts[1].message).toBe("2 つ目");
+		expect(result.current.toasts[1].variant).toBe("error");
+	});
+
+	it("dismissToast で個別に削除できる", () => {
+		const { result } = renderHook(() => useToast(), { wrapper });
+
+		act(() => {
+			result.current.showToast("削除対象");
+		});
+		const id = result.current.toasts[0].id;
+
+		act(() => {
+			result.current.dismissToast(id);
+		});
+		expect(result.current.toasts).toHaveLength(0);
+	});
+
+	it("ToastProvider 外で useToast を呼ぶとエラーになる", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => renderHook(() => useToast())).toThrow(/ToastProvider/);
+		spy.mockRestore();
+	});
+});

--- a/test/useToast.test.tsx
+++ b/test/useToast.test.tsx
@@ -38,19 +38,9 @@ describe("useToast", () => {
 		expect(result.current.toasts[0].variant).toBe("success");
 	});
 
-	it("durationMs 経過後にトーストが自動消去される", () => {
-		const { result } = renderHook(() => useToast(), { wrapper });
-
-		act(() => {
-			result.current.showToast("消えるメッセージ", { durationMs: 1000 });
-		});
-		expect(result.current.toasts).toHaveLength(1);
-
-		act(() => {
-			vi.advanceTimersByTime(1000);
-		});
-		expect(result.current.toasts).toHaveLength(0);
-	});
+	// 自動消去の振る舞いは ToastItem 側（useEffect）で実装しており、
+	// ToastContainer をレンダリングしない renderHook だけでは検証できない。
+	// DOM から消えることは test/Toast.test.tsx でカバーしている。
 
 	it("同時に複数のトーストを追加できる", () => {
 		const { result } = renderHook(() => useToast(), { wrapper });

--- a/test/useToast.test.tsx
+++ b/test/useToast.test.tsx
@@ -72,7 +72,12 @@ describe("useToast", () => {
 
 	it("ToastProvider 外で useToast を呼ぶとエラーになる", () => {
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-		expect(() => renderHook(() => useToast())).toThrow(/ToastProvider/);
-		spy.mockRestore();
+		try {
+			expect(() => renderHook(() => useToast())).toThrow(/ToastProvider/);
+		} finally {
+			// assertion が throw した場合でも console.error の spy を確実に復元する。
+			// 漏れると後続テストの本物のエラー出力が suppressed されデバッグが困難になる。
+			spy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- 通知タイミングの変更を「設定」ボタン / Enter で確定する UI に改善し、成功/失敗をトーストで通知
- 経路ごとの通知トグル ON/OFF 時にトーストを表示。文言に乗車→降車のバス停名を含め「どの経路を切り替えたか」を明示
- トグル操作時に発生していたページ先頭へのスクロール飛びと、登録ボタンの「保存中...」への揺れを解消
- 永続化（localStorage）失敗時の state 乖離を修正

## 背景

PR #87 マージ後にユーザーから 2 件の追加要望・不具合報告：

1. 通知タイミング入力欄に明示的な確定操作（ボタン）がなく分かりにくい。確定時に軽いフィードバックが欲しい
2. 経路のトグルをクリックするとページの一番上にスクロールが戻る。通知の ON/OFF でも確定時と同様にフィードバックが欲しい

追加で、以下のフィードバックも反映：

- Enter キーでの確定は維持しつつトースト表示も行う
- 「現在、出発 N 分前に通知します」の数値も設定変更に追従させる
- エラー時のみ error variant のトーストにする
- トグル操作で登録ボタンの表示が乱れる問題を解消
- トーストにはどの経路の通知を切り替えたか明示する

## 主な変更点

### 新規: トースト基盤（\`src/hooks/useToast.tsx\`, \`src/components/Toast.tsx\`）

- Context ベースの \`ToastProvider\` + \`useToast\` フック
- daisyUI \`alert-success/error/info\` + \`role=status/alert\` を variant で切替
- \`durationMs\` 指定の自動消去、閉じるボタン（\`aria-label=\"閉じる\"\`）付き

### 通知タイミング設定 UI

- 入力欄の隣に「設定」ボタン（\`aria-label=\"通知タイミングを設定\"\`）を追加
- Enter キー / 設定ボタンのどちらでも確定可能。blur による自動確定は廃止
- 現在値と同じ・範囲外・小数・空では設定ボタンを disabled
- 確定時に「通知タイミングを N 分前に設定しました」success トースト
- 失敗時は「通知タイミングを設定できませんでした: {詳細}」error トースト

### 経路トグル UX

- ON/OFF 成功時: \`{乗車} → {降車} の通知を ON/OFF にしました\` success トースト
- 失敗時: \`{乗車} → {降車} の通知設定に失敗しました: {詳細}\` error トースト
- \`togglingRouteId\` を \`submitting\` と分離し、登録/更新ボタンがトグル操作で「保存中...」に揺れる問題を解消

### スクロール飛びの修正（\`src/hooks/useRoutes.ts\`）

\`reload()\` が毎回 \`setLoading(true)\` を呼ぶことで、App.tsx の
\`{db && !loading && !error && (...)}\` ブロックが一時的にアンマウントされ、
配下の MapView/DepartureBoard/RouteRegistration が再マウントされてコンテンツ高が 0
になるためブラウザのスクロール位置がリセットされていた。
\`hasLoadedOnceRef\` を導入し、初回ロード時のみ loading を立てる仕様に変更。

### 永続化失敗時の state 乖離修正（\`src/hooks/useNotificationSettings.ts\`）

\`localStorage.setItem\` が QuotaExceededError 等で失敗した際に画面表示と保存値が
乖離しないよう、書き込み成功時のみ state を更新（失敗時は throw）。

## Test plan

- [x] \`npm run test\`: 388 tests / 28 files 全 pass
- [x] \`npm run build\`: tsc + vite ビルド成功
- [x] \`npx biome check src test\`: 変更ファイルにフォーマット適用済み（pre-existing な他ファイルの指摘は本 PR のスコープ外）
- [ ] ブラウザで通知タイミング設定: 設定ボタン / Enter で確定、トースト表示、「現在、出発 N 分前に通知します」の数値更新
- [ ] ブラウザで経路トグル ON/OFF: スクロール位置が維持されること、登録ボタンの表示が揺れないこと、トーストにバス停名が含まれること
- [ ] エクスポート/インポートで \`notifyEnabled\` が保持されること（前 PR からのリグレッション確認）

## TDD サイクルの遵守

すべての実装について Red-Green-Refactor を踏襲：

- Toast 基盤: useToast/Toast テストを先に書いて失敗確認 → 実装
- 設定ボタン/トースト: 失敗テスト 10 件を先に追加 → 実装
- トグル表示乱れ・バス停名トースト: 失敗テスト 3 件を先に追加 → 実装
- 既存の \`useRoutes\` リグレッションテスト（loading が再度 true にならない）で継続的に担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * トースト通知システムを追加。成功・エラーメッセージが画面右下に表示されるようになりました。
  * ルートの通知切り替え時にフィードバック通知が表示されるようになりました。
  * 通知タイミング設定に専用ボタンを追加し、設定結果をトースト通知で表示します。

* **Bug Fixes**
  * 通知設定の永続化処理を改善しました。
  * 非同期操作中のUI状態をより堅牢に管理するようになりました。

* **Tests**
  * 通知システムと主要機能の包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->