### PR TITLE
refactor: 通知タイミング入力の state 管理をリフトアップして useEffect 同期を廃止 (Refs #89)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { ToastContainer } from "./components/Toast";
 import { useDatabase } from "./hooks/useDatabase";
 import { useDepartures } from "./hooks/useDepartures";
 import { useNotification } from "./hooks/useNotification";
-import { useNotificationSettings } from "./hooks/useNotificationSettings";
+import { useNotifyBeforeMinutesInput } from "./hooks/useNotifyBeforeMinutesInput";
 import { useRoutes } from "./hooks/useRoutes";
 import { type ThemePreference, useTheme } from "./hooks/useTheme";
 import { ToastProvider } from "./hooks/useToast";
@@ -108,8 +108,17 @@ function AppContent() {
 
 	const { preference, changeTheme } = useTheme();
 
-	const { minutes: notifyBeforeMinutes, setMinutes: setNotifyBeforeMinutes } =
-		useNotificationSettings();
+	// 通知タイミングの確定値と入力中の値を同一スコープで管理する。
+	// 従来は RouteRegistration 内で useState + useEffect による
+	// props → state 同期を行っていたが、React アンチパターンであり
+	// 入力中に外部更新が来た場合の上書きリスクもあった（Issue #89）。
+	const {
+		minutes: notifyBeforeMinutes,
+		inputValue: notifyInputValue,
+		setInputValue: setNotifyInputValue,
+		canCommit: canCommitNotifyInput,
+		commit: commitNotifyInput,
+	} = useNotifyBeforeMinutesInput();
 
 	const allDeparturesForNotification = useMemo(
 		() =>
@@ -205,7 +214,10 @@ function AppContent() {
 							notifyPermission={notifyPermission}
 							hasNotifyEnabledRoutes={hasNotifyEnabledRoutes}
 							notifyBeforeMinutes={notifyBeforeMinutes}
-							onNotifyBeforeMinutesChange={setNotifyBeforeMinutes}
+							notifyInputValue={notifyInputValue}
+							onNotifyInputChange={setNotifyInputValue}
+							canCommitNotifyInput={canCommitNotifyInput}
+							onCommitNotifyInput={commitNotifyInput}
 						/>
 					</>
 				)}

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useMemo, useState } from "react";
 import type { Database } from "sql.js";
+import {
+	NOTIFY_MAX_MINUTES,
+	NOTIFY_MIN_MINUTES,
+} from "../constants/notification";
 import type { NotifyInputCommitResult } from "../hooks/useNotifyBeforeMinutesInput";
 import { useToast } from "../hooks/useToast";
 import { type StopSearchResult, getStopName } from "../lib/stop-search";
@@ -370,8 +374,8 @@ export function RouteRegistration({
 										id="notify-before-minutes"
 										type="number"
 										className="input input-bordered input-xs w-14"
-										min="1"
-										max="60"
+										min={NOTIFY_MIN_MINUTES}
+										max={NOTIFY_MAX_MINUTES}
 										step="1"
 										aria-describedby="notify-before-minutes-unit"
 										value={notifyInputValue ?? ""}

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -98,17 +98,21 @@ export function RouteRegistration({
 	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、
 	 * onCommitNotifyInput（親フックの commit）に委譲する。
 	 *
-	 * 設定ボタンは `disabled` 属性でガードされているが、Enter キー経路は
-	 * 無条件で呼び出されるため、canCommit=false のまま commit すると
-	 * 親フックから `invalid-or-unchanged` エラーが返ってエラートーストが
-	 * 誤表示される。そのため呼び出し側でも canCommitNotifyInput を
-	 * 明示ガードする。
+	 * 設定ボタンは `disabled` 属性で
+	 *   (!canCommit || submitting || togglingRouteId !== null)
+	 * をガードしているが、Enter キー経路は無条件で呼び出されるため、
+	 * 呼び出し側でも同じ busy / validity 条件を明示ガードする。これは
+	 * 「busy 中は全確定経路を塞ぐ」という UI invariant と、
+	 * `invalid-or-unchanged` エラーがエラートーストとして誤表示されるのを
+	 * 防ぐためである。
 	 *
 	 * コールバック未指定時は「設定しました」トーストの誤表示を防ぐため
 	 * 明示的に no-op。入力値・確定値・ロールバックは親フック側の責務で、
 	 * ここでは commit 結果に応じたトースト出力のみを担当する。
 	 */
 	const commitNotifyInput = () => {
+		// ボタン側の disabled 条件と対称に busy 状態を先にガードする
+		if (submitting || togglingRouteId !== null) return;
 		if (!canCommitNotifyInput) return;
 		if (!onCommitNotifyInput) return;
 		const result = onCommitNotifyInput();

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { Database } from "sql.js";
+import type { NotifyInputCommitResult } from "../hooks/useNotifyBeforeMinutesInput";
 import { useToast } from "../hooks/useToast";
 import { type StopSearchResult, getStopName } from "../lib/stop-search";
 import type { RegisteredRouteEntry, RouteEntry } from "../types/route-entry";
@@ -22,10 +23,16 @@ type RouteRegistrationProps = {
 	notifyPermission?: NotificationPermission | "unsupported";
 	/** 通知が有効な経路が 1 件以上あるかどうか */
 	hasNotifyEnabledRoutes?: boolean;
-	/** 通知する出発目安の何分前（undefined のとき通知タイミング UI を非表示） */
+	/** 通知する出発目安の何分前（確定値／表示用、undefined のとき通知タイミング UI を非表示） */
 	notifyBeforeMinutes?: number;
-	/** 通知タイミング変更コールバック */
-	onNotifyBeforeMinutesChange?: (minutes: number) => void;
+	/** 通知タイミングの入力中文字列（制御コンポーネント） */
+	notifyInputValue?: string;
+	/** 入力値変更ハンドラ */
+	onNotifyInputChange?: (value: string) => void;
+	/** 入力値が有効かつ未保存の変更を含むかどうか */
+	canCommitNotifyInput?: boolean;
+	/** 入力値の確定ハンドラ。成功/失敗と確定後の値を返す */
+	onCommitNotifyInput?: () => NotifyInputCommitResult;
 };
 
 type FormState = {
@@ -53,7 +60,10 @@ export function RouteRegistration({
 	notifyPermission,
 	hasNotifyEnabledRoutes,
 	notifyBeforeMinutes,
-	onNotifyBeforeMinutesChange,
+	notifyInputValue,
+	onNotifyInputChange,
+	canCommitNotifyInput,
+	onCommitNotifyInput,
 }: RouteRegistrationProps) {
 	const stopNameMap = useMemo(() => {
 		const ids = new Set<string>();
@@ -83,60 +93,33 @@ export function RouteRegistration({
 
 	const { showToast } = useToast();
 
-	// 通知分前入力のローカル表示値（一時クリアを許容するため string で管理）
-	const [notifyInputValue, setNotifyInputValue] = useState(() =>
-		notifyBeforeMinutes !== undefined ? String(notifyBeforeMinutes) : "",
-	);
-	// 外部から prop が変更された場合（localStorage 初期読込等）に同期する
-	useEffect(() => {
-		if (notifyBeforeMinutes !== undefined) {
-			setNotifyInputValue(String(notifyBeforeMinutes));
-		}
-	}, [notifyBeforeMinutes]);
-
-	/**
-	 * 現在の入力値が有効（整数かつ 1〜60）かどうか。
-	 * UI 属性 min="1" max="60" step="1" と意図を揃える。
-	 */
-	const notifyInputParsed = Number(notifyInputValue);
-	const isNotifyInputValid =
-		notifyInputValue.trim() !== "" &&
-		Number.isInteger(notifyInputParsed) &&
-		notifyInputParsed >= 1 &&
-		notifyInputParsed <= 60;
-	const isNotifyInputChanged =
-		notifyBeforeMinutes === undefined ||
-		notifyInputParsed !== notifyBeforeMinutes;
-	const canCommitNotifyInput = isNotifyInputValid && isNotifyInputChanged;
-
 	/**
 	 * 通知分前入力の確定処理。
-	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、onNotifyBeforeMinutesChange
-	 * に伝播する。呼び出し元が throw した場合はエラートーストで通知する。
-	 * コールバック未指定時は optional chaining で silently no-op するだけでは
-	 * 「設定しました」トーストが誤表示されるため、明示的にガードする。
+	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、
+	 * onCommitNotifyInput（親フックの commit）に委譲する。
+	 *
+	 * コールバック未指定時は「設定しました」トーストの誤表示を防ぐため
+	 * 明示的に no-op。入力値・確定値・ロールバックは親フック側の責務で、
+	 * ここでは commit 結果に応じたトースト出力のみを担当する。
 	 */
 	const commitNotifyInput = () => {
-		if (!canCommitNotifyInput) return;
-		if (!onNotifyBeforeMinutesChange) return;
-		try {
-			onNotifyBeforeMinutesChange(notifyInputParsed);
+		if (!onCommitNotifyInput) return;
+		const result = onCommitNotifyInput();
+		if (result.ok) {
 			showToast(
-				`発車の ${notifyInputParsed} 分前に通知するように設定しました`,
+				`発車の ${result.committedMinutes} 分前に通知するように設定しました`,
 				{ variant: "success" },
 			);
-		} catch (err) {
-			const detail = err instanceof Error ? err.message : String(err);
-			showToast(`通知タイミングを設定できませんでした: ${detail}`, {
-				variant: "error",
-			});
-			// 確定に失敗したのに入力欄だけ新しい値のまま残ると、保存済みの値と
-			// 画面表示が乖離してユーザーの誤解を招く。props の現在値へロールバック
-			// して、表示と永続化値の整合を保つ。
-			if (notifyBeforeMinutes !== undefined) {
-				setNotifyInputValue(String(notifyBeforeMinutes));
-			}
+			return;
 		}
+		// canCommit=false 等の既知ガード漏れは、親が設定ボタンの disabled を
+		// 正しく制御している前提では起こらない。ここへ来る失敗は
+		// 永続化失敗等の本物のエラーのためエラートーストで通知する。
+		const detail =
+			result.error instanceof Error ? result.error.message : String(result.error);
+		showToast(`通知タイミングを設定できませんでした: ${detail}`, {
+			variant: "error",
+		});
 	};
 
 	const resetForm = useCallback(() => {
@@ -381,11 +364,11 @@ export function RouteRegistration({
 										max="60"
 										step="1"
 										aria-describedby="notify-before-minutes-unit"
-										value={notifyInputValue}
+										value={notifyInputValue ?? ""}
 										onChange={(e) => {
 											// 確定は Enter キー / 設定ボタンで行う（入力中の逐次 persist を防ぐ）。
 											// blur による自動確定は廃止（意図しない確定を避けるため）。
-											setNotifyInputValue(e.target.value);
+											onNotifyInputChange?.(e.target.value);
 										}}
 										onKeyDown={(e) => {
 											if (e.key === "Enter") {
@@ -405,7 +388,7 @@ export function RouteRegistration({
 										className="btn btn-xs btn-primary"
 										onClick={commitNotifyInput}
 										disabled={
-											!canCommitNotifyInput ||
+											!(canCommitNotifyInput ?? false) ||
 											submitting ||
 											togglingRouteId !== null
 										}

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -98,11 +98,18 @@ export function RouteRegistration({
 	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、
 	 * onCommitNotifyInput（親フックの commit）に委譲する。
 	 *
+	 * 設定ボタンは `disabled` 属性でガードされているが、Enter キー経路は
+	 * 無条件で呼び出されるため、canCommit=false のまま commit すると
+	 * 親フックから `invalid-or-unchanged` エラーが返ってエラートーストが
+	 * 誤表示される。そのため呼び出し側でも canCommitNotifyInput を
+	 * 明示ガードする。
+	 *
 	 * コールバック未指定時は「設定しました」トーストの誤表示を防ぐため
 	 * 明示的に no-op。入力値・確定値・ロールバックは親フック側の責務で、
 	 * ここでは commit 結果に応じたトースト出力のみを担当する。
 	 */
 	const commitNotifyInput = () => {
+		if (!canCommitNotifyInput) return;
 		if (!onCommitNotifyInput) return;
 		const result = onCommitNotifyInput();
 		if (result.ok) {
@@ -112,9 +119,8 @@ export function RouteRegistration({
 			);
 			return;
 		}
-		// canCommit=false 等の既知ガード漏れは、親が設定ボタンの disabled を
-		// 正しく制御している前提では起こらない。ここへ来る失敗は
-		// 永続化失敗等の本物のエラーのためエラートーストで通知する。
+		// 冒頭で canCommit=false をガード済みのため、ここへ来る失敗は
+		// 永続化失敗等の本物のエラーに限られる。エラートーストで通知する。
 		const detail =
 			result.error instanceof Error ? result.error.message : String(result.error);
 		showToast(`通知タイミングを設定できませんでした: ${detail}`, {

--- a/src/constants/notification.ts
+++ b/src/constants/notification.ts
@@ -1,0 +1,16 @@
+/**
+ * 通知タイミング（発車の何分前か）に関する定数。
+ *
+ * 以下の 3 箇所で同じ値を参照する必要があるため、ここに集約する:
+ * - useNotificationSettings: 永続化時のクランプ範囲 / デフォルト値
+ * - useNotifyBeforeMinutesInput: 入力値バリデーション範囲
+ * - RouteRegistration: number 入力の min / max HTML 属性
+ *
+ * 値の意味:
+ * - NOTIFY_MIN_MINUTES: 発車の何分前に通知するかの最小値（分）
+ * - NOTIFY_MAX_MINUTES: 同最大値（分）
+ * - NOTIFY_DEFAULT_MINUTES: 未保存時のデフォルト値（分）
+ */
+export const NOTIFY_MIN_MINUTES = 1;
+export const NOTIFY_MAX_MINUTES = 60;
+export const NOTIFY_DEFAULT_MINUTES = 5;

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -1,20 +1,30 @@
 import { useCallback, useState } from "react";
+import {
+	NOTIFY_DEFAULT_MINUTES,
+	NOTIFY_MAX_MINUTES,
+	NOTIFY_MIN_MINUTES,
+} from "../constants/notification";
 
 const STORAGE_KEY = "notify-before-minutes";
-const DEFAULT_MINUTES = 5;
 
 /** 通知タイミング（発車の何分前か）を管理するフック */
 export function useNotificationSettings() {
 	const [minutes, setMinutesState] = useState<number>(() => {
 		const stored = localStorage.getItem(STORAGE_KEY);
-		if (stored == null) return DEFAULT_MINUTES;
+		if (stored == null) return NOTIFY_DEFAULT_MINUTES;
 		const n = Number(stored);
-		if (!Number.isFinite(n) || n <= 0) return DEFAULT_MINUTES;
-		return Math.max(1, Math.min(60, Math.floor(n)));
+		if (!Number.isFinite(n) || n <= 0) return NOTIFY_DEFAULT_MINUTES;
+		return Math.max(
+			NOTIFY_MIN_MINUTES,
+			Math.min(NOTIFY_MAX_MINUTES, Math.floor(n)),
+		);
 	});
 
 	const setMinutes = useCallback((value: number) => {
-		const clamped = Math.max(1, Math.min(60, Math.floor(value)));
+		const clamped = Math.max(
+			NOTIFY_MIN_MINUTES,
+			Math.min(NOTIFY_MAX_MINUTES, Math.floor(value)),
+		);
 		// 永続化を先に試行し、成功した場合のみ state を更新する。
 		// localStorage の書き込み失敗時（QuotaExceededError 等）に
 		// 画面表示と保存値が乖離しないようにする。失敗時は throw して

--- a/src/hooks/useNotifyBeforeMinutesInput.ts
+++ b/src/hooks/useNotifyBeforeMinutesInput.ts
@@ -1,4 +1,8 @@
 import { useCallback, useState } from "react";
+import {
+	NOTIFY_MAX_MINUTES,
+	NOTIFY_MIN_MINUTES,
+} from "../constants/notification";
 import { useNotificationSettings } from "./useNotificationSettings";
 
 /**
@@ -9,10 +13,6 @@ import { useNotificationSettings } from "./useNotificationSettings";
 export type NotifyInputCommitResult =
 	| { ok: true; committedMinutes: number }
 	| { ok: false; error: unknown };
-
-/** 通知タイミング（発車の何分前か）の入力値が満たすべき範囲 */
-const MIN_MINUTES = 1;
-const MAX_MINUTES = 60;
 
 /**
  * 通知タイミング入力の確定値と編集中の値を同一スコープで保持するフック。
@@ -37,8 +37,8 @@ export function useNotifyBeforeMinutesInput() {
 	const isValid =
 		inputValue.trim() !== "" &&
 		Number.isInteger(parsed) &&
-		parsed >= MIN_MINUTES &&
-		parsed <= MAX_MINUTES;
+		parsed >= NOTIFY_MIN_MINUTES &&
+		parsed <= NOTIFY_MAX_MINUTES;
 	const isChanged = parsed !== minutes;
 	const canCommit = isValid && isChanged;
 

--- a/src/hooks/useNotifyBeforeMinutesInput.ts
+++ b/src/hooks/useNotifyBeforeMinutesInput.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from "react";
+import { useNotificationSettings } from "./useNotificationSettings";
+
+/**
+ * commit() の戻り値。
+ * - ok: true  … 永続化に成功した場合（committedMinutes が新しい確定値）
+ * - ok: false … 永続化失敗または canCommit=false の場合。error にエラー内容が入る。
+ */
+export type NotifyInputCommitResult =
+	| { ok: true; committedMinutes: number }
+	| { ok: false; error: unknown };
+
+/** 通知タイミング（発車の何分前か）の入力値が満たすべき範囲 */
+const MIN_MINUTES = 1;
+const MAX_MINUTES = 60;
+
+/**
+ * 通知タイミング入力の確定値と編集中の値を同一スコープで保持するフック。
+ *
+ * 従来は RouteRegistration 内に `useState(inputValue)` と
+ * `useEffect(() => setInputValue(minutes))` による props → state 同期が
+ * 存在していた。この構造はユーザー入力中に外部から minutes が更新された
+ * 場合に編集途中の値を破壊する典型的なアンチパターンである
+ * （Issue #89）。
+ *
+ * 本フックは確定値（useNotificationSettings の minutes）と
+ * 編集中の値（inputValue）を同一スコープで管理し、
+ * 編集開始後は minutes が変わっても inputValue が書き換えられない
+ * 性質を保証する。RouteRegistration は純粋な制御コンポーネントとなり
+ * useEffect 同期が不要になる。
+ */
+export function useNotifyBeforeMinutesInput() {
+	const { minutes, setMinutes } = useNotificationSettings();
+	const [inputValue, setInputValue] = useState<string>(() => String(minutes));
+
+	const parsed = Number(inputValue);
+	const isValid =
+		inputValue.trim() !== "" &&
+		Number.isInteger(parsed) &&
+		parsed >= MIN_MINUTES &&
+		parsed <= MAX_MINUTES;
+	const isChanged = parsed !== minutes;
+	const canCommit = isValid && isChanged;
+
+	const commit = useCallback((): NotifyInputCommitResult => {
+		if (!canCommit) {
+			// 無効値・未変更の状態で呼ばれた場合は呼び出し側のガードが漏れている。
+			// 明示的にエラーとして返し、誤ったトースト表示を誘発しないようにする。
+			return { ok: false, error: new Error("invalid-or-unchanged") };
+		}
+		try {
+			setMinutes(parsed);
+			return { ok: true, committedMinutes: parsed };
+		} catch (err) {
+			// 永続化失敗時は入力欄を確定済み値へロールバックし、
+			// 画面表示と保存値の乖離を防ぐ。
+			setInputValue(String(minutes));
+			return { ok: false, error: err };
+		}
+	}, [canCommit, minutes, parsed, setMinutes]);
+
+	return { minutes, inputValue, setInputValue, canCommit, commit } as const;
+}

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -5,7 +5,7 @@ import {
 	screen,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import initSqlJs from "sql.js";
 import {
 	afterEach,
@@ -16,8 +16,10 @@ import {
 	it,
 	vi,
 } from "vitest";
+import type { Database } from "sql.js";
 import { RouteRegistration } from "../src/components/RouteRegistration";
 import { ToastContainer } from "../src/components/Toast";
+import type { NotifyInputCommitResult } from "../src/hooks/useNotifyBeforeMinutesInput";
 import { ToastProvider } from "../src/hooks/useToast";
 import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
 import type { GtfsData } from "../src/types/gtfs";
@@ -104,6 +106,71 @@ function renderComponent(routes: RegisteredRouteEntry[] = []) {
 	);
 
 	return { onAdd, onUpdate, onDelete };
+}
+
+/**
+ * 通知タイミング UI の対話系テスト向けハーネス。
+ * useNotifyBeforeMinutesInput の振る舞いを等価に再現しつつ、
+ * commit 成功時のスパイ注入・失敗時の挙動確認を可能にする。
+ *
+ * 実フック (`useNotifyBeforeMinutesInput`) と異なり localStorage には
+ * 触れず、confirmation 専用のインメモリ状態だけで動作する。これにより
+ * テスト間での localStorage 漏れを避けつつ、確定値・入力値の同一スコープ
+ * 管理による「入力中の外部更新保護」の振る舞いを再現できる。
+ */
+function NotifyHarness(props: {
+	db: Database;
+	routes: RegisteredRouteEntry[];
+	onAdd: (entry: Omit<import("../src/types/route-entry").RouteEntry, "id">) => Promise<number>;
+	onUpdate: (entry: RegisteredRouteEntry) => Promise<void>;
+	onDelete: (id: number) => Promise<void>;
+	onRequestNotificationPermission?: () => Promise<NotificationPermission>;
+	notifyPermission?: NotificationPermission | "unsupported";
+	hasNotifyEnabledRoutes?: boolean;
+	initialMinutes?: number;
+	/** commit 時に minutes 引数で呼ばれる。throw すると rollback される */
+	onCommitSpy?: (minutes: number) => void;
+}) {
+	const {
+		initialMinutes = 5,
+		onCommitSpy,
+		...componentProps
+	} = props;
+	const [minutes, setMinutes] = useState(initialMinutes);
+	const [inputValue, setInputValue] = useState(String(initialMinutes));
+
+	const parsed = Number(inputValue);
+	const isValid =
+		inputValue.trim() !== "" &&
+		Number.isInteger(parsed) &&
+		parsed >= 1 &&
+		parsed <= 60;
+	const canCommit = isValid && parsed !== minutes;
+
+	const commit = (): NotifyInputCommitResult => {
+		if (!canCommit) {
+			return { ok: false, error: new Error("invalid-or-unchanged") };
+		}
+		try {
+			onCommitSpy?.(parsed);
+			setMinutes(parsed);
+			return { ok: true, committedMinutes: parsed };
+		} catch (err) {
+			setInputValue(String(minutes));
+			return { ok: false, error: err };
+		}
+	};
+
+	return (
+		<RouteRegistration
+			{...componentProps}
+			notifyBeforeMinutes={minutes}
+			notifyInputValue={inputValue}
+			onNotifyInputChange={setInputValue}
+			canCommitNotifyInput={canCommit}
+			onCommitNotifyInput={commit}
+		/>
+	);
 }
 
 describe("RouteRegistration コンポーネント", () => {
@@ -936,16 +1003,21 @@ describe("RouteRegistration コンポーネント", () => {
 			},
 		];
 
+		/** 共通の必須コールバック。テスト側で上書きしたい場合のみ渡す */
+		const baseHandlers = () => ({
+			onAdd: vi.fn().mockResolvedValue(1),
+			onUpdate: vi.fn().mockResolvedValue(undefined),
+			onDelete: vi.fn().mockResolvedValue(undefined),
+		});
+
 		it("hasNotifyEnabledRoutes=true のとき現在値が明示表示される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
+					initialMinutes={5}
 				/>,
 			);
 			expect(
@@ -955,14 +1027,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("hasNotifyEnabledRoutes=true のとき変更用の入力が表示される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
+					initialMinutes={5}
 				/>,
 			);
 			expect(
@@ -972,14 +1042,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("変更用入力には単位「分前」が accessible description として関連付けられている", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -996,14 +1064,12 @@ describe("RouteRegistration コンポーネント", () => {
 				},
 			];
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={routes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={false}
-					notifyBeforeMinutes={5}
+					initialMinutes={5}
 				/>,
 			);
 			expect(
@@ -1014,14 +1080,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("notifyPermission が default のとき「通知を許可」ボタンが表示される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
+					initialMinutes={5}
 					notifyPermission="default"
 					onRequestNotificationPermission={vi.fn().mockResolvedValue("granted")}
 				/>,
@@ -1033,15 +1097,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("設定ボタンが表示される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			expect(
@@ -1049,18 +1110,16 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeInTheDocument();
 		});
 
-		it("値を変更して設定ボタンを押すと onNotifyBeforeMinutesChange が呼ばれる", async () => {
-			const onChange = vi.fn();
+		it("値を変更して設定ボタンを押すと commit が呼ばれ確定値が更新される", async () => {
+			const onCommitSpy = vi.fn();
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1068,21 +1127,22 @@ describe("RouteRegistration コンポーネント", () => {
 			await userEvent.click(
 				screen.getByRole("button", { name: "通知タイミングを設定" }),
 			);
-			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith(15);
+			expect(onCommitSpy).toHaveBeenCalledTimes(1);
+			expect(onCommitSpy).toHaveBeenCalledWith(15);
+			// 確定後は確定値表示も更新される
+			expect(
+				screen.getByText(/現在、出発\s*15\s*分前に通知します/),
+			).toBeInTheDocument();
 		});
 
 		it("設定ボタン押下で成功トーストが表示される", async () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1097,25 +1157,23 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeInTheDocument();
 		});
 
-		it("Enter キー押下でも onNotifyBeforeMinutesChange が呼ばれ成功トーストが表示される", async () => {
-			const onChange = vi.fn();
+		it("Enter キー押下でも commit が呼ばれ成功トーストが表示される", async () => {
+			const onCommitSpy = vi.fn();
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "20" } });
 			fireEvent.keyDown(input, { key: "Enter" });
-			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith(20);
+			expect(onCommitSpy).toHaveBeenCalledTimes(1);
+			expect(onCommitSpy).toHaveBeenCalledWith(20);
 			expect(
 				await screen.findByText(
 					/発車の\s*20\s*分前に通知するように設定しました/,
@@ -1123,88 +1181,76 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeInTheDocument();
 		});
 
-		it("onNotifyBeforeMinutesChange が未指定の場合は成功トーストが表示されない", async () => {
-			// optional chaining で silently no-op するだけでは、コールバック未指定時に
-			// 「設定しました」トーストが誤って表示され、ユーザーに未実施の操作が
-			// 完了したかのような誤情報を伝えてしまう。コールバックが実際に呼ばれた
-			// 場合のみ成功トーストを出すべき。
+		it("onCommitNotifyInput が未指定の場合は成功トーストが表示されない", async () => {
+			// 親が commit ハンドラを渡していないとき（例えば feature flag OFF 等）に
+			// 「設定しました」トーストが誤って表示されるとユーザーに未実施の操作が
+			// 完了したかのような誤情報を伝えてしまう。ハンドラ未指定時は no-op すべき。
 			render(
 				<RouteRegistration
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
 					notifyBeforeMinutes={5}
-					// onNotifyBeforeMinutesChange を意図的に渡さない
+					notifyInputValue="5"
+					onNotifyInputChange={() => {}}
+					canCommitNotifyInput={true}
+					// onCommitNotifyInput を意図的に渡さない
 				/>,
 			);
-			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
-			fireEvent.change(input, { target: { value: "15" } });
 			await userEvent.click(
 				screen.getByRole("button", { name: "通知タイミングを設定" }),
 			);
 			// 成功トーストが出てはならない
 			expect(
-				screen.queryByText(/発車の\s*15\s*分前に通知するように設定しました/),
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByText(/通知タイミングを\s*15\s*分前に設定しました/),
+				screen.queryByText(/発車の.*分前に通知するように設定しました/),
 			).not.toBeInTheDocument();
 		});
 
-		it("blur では onNotifyBeforeMinutesChange が呼ばれない（確定は Enter / 設定ボタンのみ）", () => {
-			const onChange = vi.fn();
+		it("blur では commit が呼ばれない（確定は Enter / 設定ボタンのみ）", () => {
+			const onCommitSpy = vi.fn();
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "15" } });
 			fireEvent.blur(input);
-			expect(onChange).not.toHaveBeenCalled();
+			expect(onCommitSpy).not.toHaveBeenCalled();
 		});
 
-		it("入力を変更しただけでは onNotifyBeforeMinutesChange は呼ばれない", () => {
-			const onChange = vi.fn();
+		it("入力を変更しただけでは commit は呼ばれない", () => {
+			const onCommitSpy = vi.fn();
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
 			fireEvent.change(input, { target: { value: "1" } });
 			fireEvent.change(input, { target: { value: "15" } });
-			expect(onChange).not.toHaveBeenCalled();
+			expect(onCommitSpy).not.toHaveBeenCalled();
 		});
 
 		it("現在値と同じ値では設定ボタンが無効化される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			// 初期値が 5 で入力値も 5 のまま
@@ -1215,15 +1261,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("範囲外の値（60 超）では設定ボタンが無効化される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1235,15 +1278,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("小数値では設定ボタンが無効化される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1255,15 +1295,12 @@ describe("RouteRegistration コンポーネント", () => {
 
 		it("空値では設定ボタンが無効化される", () => {
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1273,20 +1310,18 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeDisabled();
 		});
 
-		it("onNotifyBeforeMinutesChange が throw した場合はエラートーストが表示される", async () => {
-			const onChange = vi.fn().mockImplementation(() => {
+		it("commit が throw した場合はエラートーストが表示される", async () => {
+			const onCommitSpy = vi.fn().mockImplementation(() => {
 				throw new Error("localStorage 書き込みに失敗しました");
 			});
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1311,15 +1346,14 @@ describe("RouteRegistration コンポーネント", () => {
 					}),
 			);
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
 					onAdd={vi.fn().mockResolvedValue(1)}
 					onUpdate={vi.fn().mockResolvedValue(undefined)}
 					onDelete={onDelete}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			// 入力値を変更して canCommitNotifyInput=true にしておく
@@ -1346,15 +1380,14 @@ describe("RouteRegistration コンポーネント", () => {
 					}),
 			);
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
 					onAdd={vi.fn().mockResolvedValue(1)}
 					onUpdate={onUpdate}
 					onDelete={vi.fn().mockResolvedValue(undefined)}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={vi.fn()}
+					initialMinutes={5}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1373,23 +1406,21 @@ describe("RouteRegistration コンポーネント", () => {
 			resolveUpdate();
 		});
 
-		it("onNotifyBeforeMinutesChange が throw したら入力欄の表示が元の値に戻る", async () => {
+		it("commit が失敗したとき入力欄の表示が元の値に戻る", async () => {
 			// 設定確定に失敗したのに入力欄だけ新しい値のまま残ると、
 			// 保存されている値と画面表示が乖離してユーザーの誤解を招く。
-			// 失敗時は確定直前の値（props の notifyBeforeMinutes）へロールバックする。
-			const onChange = vi.fn().mockImplementation(() => {
+			// 失敗時は確定直前の値へロールバックする（親フックの責務）。
+			const onCommitSpy = vi.fn().mockImplementation(() => {
 				throw new Error("localStorage 書き込みに失敗しました");
 			});
 			render(
-				<RouteRegistration
+				<NotifyHarness
 					db={db}
 					routes={notifyEnabledRoutes}
-					onAdd={vi.fn().mockResolvedValue(1)}
-					onUpdate={vi.fn().mockResolvedValue(undefined)}
-					onDelete={vi.fn().mockResolvedValue(undefined)}
+					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
-					notifyBeforeMinutes={5}
-					onNotifyBeforeMinutesChange={onChange}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
 				/>,
 			);
 			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
@@ -1403,6 +1434,59 @@ describe("RouteRegistration コンポーネント", () => {
 				await screen.findByText(/通知タイミング.*設定できませんでした/),
 			).toBeInTheDocument();
 			expect(input).toHaveValue(5);
+		});
+
+		it("外部から notifyBeforeMinutes が更新されても入力中の値が破壊されない（Issue #89）", () => {
+			// 従来 RouteRegistration は notifyBeforeMinutes の変化を useEffect で
+			// 内部 state に同期していたため、ユーザーが編集中に親の確定値が
+			// 変わると入力途中の値が上書きされるアンチパターンが存在した。
+			// リフトアップ後は制御コンポーネントとなり、親が notifyInputValue を
+			// 明示的に変更しない限り入力は保持される。
+			function ExternalMinutesChanger() {
+				const [externalMinutes, setExternalMinutes] = useState(5);
+				// 入力値だけはローカル維持（親は inputValue を確定値と独立に扱う）
+				const [inputValue, setInputValue] = useState("5");
+				return (
+					<>
+						<button
+							type="button"
+							onClick={() => setExternalMinutes(30)}
+							data-testid="force-change-external"
+						>
+							外部から minutes を 30 に変更
+						</button>
+						<RouteRegistration
+							db={db}
+							routes={notifyEnabledRoutes}
+							{...baseHandlers()}
+							hasNotifyEnabledRoutes={true}
+							notifyBeforeMinutes={externalMinutes}
+							notifyInputValue={inputValue}
+							onNotifyInputChange={setInputValue}
+							canCommitNotifyInput={false}
+							onCommitNotifyInput={() => ({
+								ok: true,
+								committedMinutes: Number(inputValue),
+							})}
+						/>
+					</>
+				);
+			}
+			render(<ExternalMinutesChanger />);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+
+			// ユーザーが編集中（確定前）
+			fireEvent.change(input, { target: { value: "12" } });
+			expect(input).toHaveValue(12);
+
+			// 外部（親の別経路）から notifyBeforeMinutes が 30 へ変わる
+			fireEvent.click(screen.getByTestId("force-change-external"));
+
+			// 確定値表示は 30 に追従するが、入力中の値 12 は壊されない
+			expect(
+				screen.getByText(/現在、出発\s*30\s*分前に通知します/),
+			).toBeInTheDocument();
+			expect(input).toHaveValue(12);
 		});
 	});
 

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1422,6 +1422,86 @@ describe("RouteRegistration コンポーネント", () => {
 			resolveDelete();
 		});
 
+		it("submitting=true 中は Enter キーを押しても commit が呼ばれない", async () => {
+			// 設定ボタンは disabled でガードされているが、Enter キー経路も
+			// ボタンと同じ busy 条件でガードされないと「busy 中は全確定経路を塞ぐ」
+			// という UI invariant が崩れる（PR #92 CodeRabbit 指摘）。
+			let resolveDelete: () => void = () => {};
+			const onDelete = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveDelete = r;
+					}),
+			);
+			const onCommitSpy = vi.fn();
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={onDelete}
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+
+			// 削除をクリックして submitting=true を作る
+			await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+			// busy 中に Enter を押しても commit は呼ばれない
+			fireEvent.keyDown(input, { key: "Enter" });
+			expect(onCommitSpy).not.toHaveBeenCalled();
+			// トーストも出ない
+			expect(
+				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+			).not.toBeInTheDocument();
+
+			resolveDelete();
+		});
+
+		it("togglingRouteId !== null 中は Enter キーを押しても commit が呼ばれない", async () => {
+			let resolveUpdate: () => void = () => {};
+			const onUpdate = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveUpdate = r;
+					}),
+			);
+			const onCommitSpy = vi.fn();
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={onUpdate}
+					onDelete={vi.fn().mockResolvedValue(undefined)}
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "15" } });
+
+			// トグルをクリックして togglingRouteId !== null を作る
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: "通知の切り替え" }),
+			);
+
+			// busy 中に Enter を押しても commit は呼ばれない
+			fireEvent.keyDown(input, { key: "Enter" });
+			expect(onCommitSpy).not.toHaveBeenCalled();
+			expect(
+				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+			).not.toBeInTheDocument();
+
+			resolveUpdate();
+		});
+
 		it("トグル処理中（togglingRouteId !== null）は設定ボタンが disabled になる", async () => {
 			let resolveUpdate: () => void = () => {};
 			const onUpdate = vi.fn(

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1310,6 +1310,57 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeDisabled();
 		});
 
+		it("canCommit=false の状態で Enter キーを押してもエラートーストが表示されない", async () => {
+			// 設定ボタンは disabled でガードされているが、Enter キー経路は
+			// 無条件で commitNotifyInput を呼ぶため、ガードが漏れると
+			// 親フックから invalid-or-unchanged エラーが返り、ユーザーに
+			// 不適切なエラートーストが表示されてしまう（PR #92 レビュー指摘）。
+			const onCommitSpy = vi.fn();
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					{...baseHandlers()}
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+					onCommitSpy={onCommitSpy}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			// 初期値 5 のまま何も変更せず Enter キーを押す（canCommit=false）
+			fireEvent.keyDown(input, { key: "Enter" });
+			// コンポーネント側の canCommit ガードにより commit 呼び出し自体が抑止され、
+			// エラー / 成功どちらのトーストも出てはならない。
+			expect(
+				screen.queryByText(/通知タイミングを設定できませんでした/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+			).not.toBeInTheDocument();
+			// 親フックの commit 自体が呼ばれないことも明示的に検証する
+			expect(onCommitSpy).not.toHaveBeenCalled();
+		});
+
+		it("無効値の状態で Enter キーを押してもエラートーストが表示されない", () => {
+			// 範囲外等の無効値入力で Enter キーを押した場合も、エラートーストを
+			// 出さない（バリデーション表示は別責務で、ここでは無反応でよい）。
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					{...baseHandlers()}
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			fireEvent.change(input, { target: { value: "100" } });
+			fireEvent.keyDown(input, { key: "Enter" });
+			expect(
+				screen.queryByText(/通知タイミングを設定できませんでした/),
+			).not.toBeInTheDocument();
+		});
+
 		it("commit が throw した場合はエラートーストが表示される", async () => {
 			const onCommitSpy = vi.fn().mockImplementation(() => {
 				throw new Error("localStorage 書き込みに失敗しました");

--- a/test/useNotifyBeforeMinutesInput.test.ts
+++ b/test/useNotifyBeforeMinutesInput.test.ts
@@ -1,0 +1,179 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNotifyBeforeMinutesInput } from "../src/hooks/useNotifyBeforeMinutesInput";
+
+const STORAGE_KEY = "notify-before-minutes";
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+describe("useNotifyBeforeMinutesInput", () => {
+	it("初期状態で inputValue は minutes の文字列表現と一致する", () => {
+		localStorage.setItem(STORAGE_KEY, "8");
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		expect(result.current.minutes).toBe(8);
+		expect(result.current.inputValue).toBe("8");
+	});
+
+	it("setInputValue は inputValue のみを変更し minutes は変わらない", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const initialMinutes = result.current.minutes;
+
+		act(() => {
+			result.current.setInputValue("30");
+		});
+
+		expect(result.current.inputValue).toBe("30");
+		expect(result.current.minutes).toBe(initialMinutes);
+	});
+
+	it("有効な変更済みの値に対して canCommit が true になる", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		// デフォルト minutes=5
+		act(() => {
+			result.current.setInputValue("15");
+		});
+		expect(result.current.canCommit).toBe(true);
+	});
+
+	it("現在値と同じ値のとき canCommit は false", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		// 初期 inputValue=5, minutes=5
+		expect(result.current.canCommit).toBe(false);
+	});
+
+	it("範囲外（0 以下）の入力では canCommit は false", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		act(() => {
+			result.current.setInputValue("0");
+		});
+		expect(result.current.canCommit).toBe(false);
+	});
+
+	it("範囲外（60 超）の入力では canCommit は false", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		act(() => {
+			result.current.setInputValue("61");
+		});
+		expect(result.current.canCommit).toBe(false);
+	});
+
+	it("小数の入力では canCommit は false", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		act(() => {
+			result.current.setInputValue("5.5");
+		});
+		expect(result.current.canCommit).toBe(false);
+	});
+
+	it("空文字の入力では canCommit は false", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		act(() => {
+			result.current.setInputValue("");
+		});
+		expect(result.current.canCommit).toBe(false);
+	});
+
+	it("commit() は有効な入力を minutes に反映し { ok: true } を返す", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+
+		act(() => {
+			result.current.setInputValue("20");
+		});
+
+		let ret:
+			| { ok: true; committedMinutes: number }
+			| { ok: false; error: unknown }
+			| undefined;
+		act(() => {
+			ret = result.current.commit();
+		});
+
+		expect(ret).toEqual({ ok: true, committedMinutes: 20 });
+		expect(result.current.minutes).toBe(20);
+		expect(result.current.inputValue).toBe("20");
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("20");
+	});
+
+	it("commit() で setMinutes が throw したら inputValue は元の minutes にロールバックされる", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const initialMinutes = result.current.minutes;
+
+		act(() => {
+			result.current.setInputValue("25");
+		});
+		expect(result.current.inputValue).toBe("25");
+
+		const setItemSpy = vi
+			.spyOn(Storage.prototype, "setItem")
+			.mockImplementation(() => {
+				throw new DOMException("quota exceeded", "QuotaExceededError");
+			});
+
+		try {
+			let ret:
+				| { ok: true; committedMinutes: number }
+				| { ok: false; error: unknown }
+				| undefined;
+			act(() => {
+				ret = result.current.commit();
+			});
+
+			expect(ret?.ok).toBe(false);
+			if (ret && ret.ok === false) {
+				expect(ret.error).toBeInstanceOf(DOMException);
+			}
+			// minutes は変更されず、inputValue も元の値にロールバック
+			expect(result.current.minutes).toBe(initialMinutes);
+			expect(result.current.inputValue).toBe(String(initialMinutes));
+		} finally {
+			setItemSpy.mockRestore();
+		}
+	});
+
+	it("canCommit=false の状態で commit() を呼んでも minutes は変わらない", () => {
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const initialMinutes = result.current.minutes;
+
+		// 範囲外の値
+		act(() => {
+			result.current.setInputValue("999");
+		});
+
+		act(() => {
+			result.current.commit();
+		});
+
+		expect(result.current.minutes).toBe(initialMinutes);
+	});
+
+	it("commit 完了後も以降の setInputValue は minutes と独立して動作する", () => {
+		// Issue #89 の核心: 入力中の値が外部の minutes 変化で破壊されないこと。
+		// このフックでは入力状態を minutes と同じスコープで保持するため、
+		// 一度 commit した後に再度入力を始めても入力値が勝手にリセットされない。
+		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+
+		act(() => {
+			result.current.setInputValue("10");
+		});
+		act(() => {
+			result.current.commit();
+		});
+		expect(result.current.minutes).toBe(10);
+		expect(result.current.inputValue).toBe("10");
+
+		// ユーザーが新たな値を入力し始めた状況を再現
+		act(() => {
+			result.current.setInputValue("3");
+		});
+		// この時点では minutes は 10 のままで、inputValue だけが 3 になる
+		expect(result.current.minutes).toBe(10);
+		expect(result.current.inputValue).toBe("3");
+	});
+});


### PR DESCRIPTION
## 概要

Issue #89 への対応。RouteRegistration 内部で行っていた `useEffect` による props → state 同期（`notifyBeforeMinutes` → `notifyInputValue`）を廃止し、確定値と編集中の値を同一スコープで保持する `useNotifyBeforeMinutesInput` フックへリフトアップした。

これにより、ユーザーが入力中に外部で `notifyBeforeMinutes` が更新されても編集途中の値が上書きされる React アンチパターンを構造的に排除した。

Refs: #89

## 変更内容

- 新フック `src/hooks/useNotifyBeforeMinutesInput.ts`
  - `useNotificationSettings` を内包し、`inputValue` / `canCommit` / `commit` を提供
  - `commit()` は `{ ok: true; committedMinutes } | { ok: false; error }` を返す Result 型
  - 永続化失敗時のロールバックをフック側で完結
- `src/components/RouteRegistration.tsx`
  - `useEffect` 同期とローカル state / バリデーションを削除
  - 制御コンポーネント化し、`notifyInputValue` / `onNotifyInputChange` / `canCommitNotifyInput` / `onCommitNotifyInput` を props で受領
  - トースト出力のみコンポーネント側に残存
- `src/App.tsx`
  - 新フックを呼び出して RouteRegistration に配線
- テスト
  - `test/useNotifyBeforeMinutesInput.test.ts`: フック単体テスト 12 件
  - `test/RouteRegistration.test.tsx`: `NotifyHarness` を導入し commit スパイ注入で等価テスト、加えて「編集中に外部から minutes が更新されても入力が破壊されない」ケース (Issue #89 核心) を追加

## テスト結果

- `npx vitest run`: 全 413 件パス（新規 13 件含む）
- `npm run build`: 型チェック + ビルド成功

## Test Plan

- [x] フック単体テストが通る
- [x] RouteRegistration 既存テストが全て通る
- [x] Issue #89 の「外部更新で入力値が破壊されない」テストが通る
- [x] `npm run build` が通る
- [ ] （手動）ブラウザで通知タイミング入力→確定→トースト表示の挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 通知タイミング編集中に、入力値が正しく保持されるようになりました。

* **改善**
  * 通知タイミング入力の検証とエラーハンドリングが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->