### PR TITLE
refactor: 通知タイミング入力フックを RouteRegistration 内部へ移設 (#93)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { ToastContainer } from "./components/Toast";
 import { useDatabase } from "./hooks/useDatabase";
 import { useDepartures } from "./hooks/useDepartures";
 import { useNotification } from "./hooks/useNotification";
-import { useNotifyBeforeMinutesInput } from "./hooks/useNotifyBeforeMinutesInput";
+import { useNotificationSettings } from "./hooks/useNotificationSettings";
 import { useRoutes } from "./hooks/useRoutes";
 import { type ThemePreference, useTheme } from "./hooks/useTheme";
 import { ToastProvider } from "./hooks/useToast";
@@ -108,17 +108,13 @@ function AppContent() {
 
 	const { preference, changeTheme } = useTheme();
 
-	// 通知タイミングの確定値と入力中の値を同一スコープで管理する。
-	// 従来は RouteRegistration 内で useState + useEffect による
-	// props → state 同期を行っていたが、React アンチパターンであり
-	// 入力中に外部更新が来た場合の上書きリスクもあった（Issue #89）。
-	const {
-		minutes: notifyBeforeMinutes,
-		inputValue: notifyInputValue,
-		setInputValue: setNotifyInputValue,
-		canCommit: canCommitNotifyInput,
-		commit: commitNotifyInput,
-	} = useNotifyBeforeMinutesInput();
+	// 通知タイミングの確定値 (localStorage 永続化付き) のみを AppContent で保持し、
+	// 入力中文字列の state は RouteRegistration 内部の useNotifyBeforeMinutesInput
+	// が管理する。Issue #93: 入力中の文字列 state を AppContent に持たせると
+	// キー入力ごとに AppContent（配下の MapView / DepartureBoard 等も含む）が
+	// 再レンダされてしまうため、入力 state の保持を必要最小限のスコープへ移動した。
+	const { minutes: notifyBeforeMinutes, setMinutes: setNotifyBeforeMinutes } =
+		useNotificationSettings();
 
 	const allDeparturesForNotification = useMemo(
 		() =>
@@ -214,10 +210,7 @@ function AppContent() {
 							notifyPermission={notifyPermission}
 							hasNotifyEnabledRoutes={hasNotifyEnabledRoutes}
 							notifyBeforeMinutes={notifyBeforeMinutes}
-							notifyInputValue={notifyInputValue}
-							onNotifyInputChange={setNotifyInputValue}
-							canCommitNotifyInput={canCommitNotifyInput}
-							onCommitNotifyInput={commitNotifyInput}
+							setNotifyBeforeMinutes={setNotifyBeforeMinutes}
 						/>
 					</>
 				)}

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import type { Database } from "sql.js";
 import {
-	NOTIFY_DEFAULT_MINUTES,
 	NOTIFY_MAX_MINUTES,
 	NOTIFY_MIN_MINUTES,
 } from "../constants/notification";
@@ -38,13 +37,6 @@ type RouteRegistrationProps = {
 	setNotifyBeforeMinutes?: (value: number) => void;
 };
 
-/**
- * setNotifyBeforeMinutes 未指定時のフォールバック。useState 初期化子が一度だけ
- * この参照を見るためモジュールスコープで定義して安定参照を提供する。通知タイミング
- * UI は表示条件で非表示化されるため、この no-op が実際に呼ばれることはない。
- */
-const NOOP_SET_MINUTES = (_value: number) => {};
-
 type FormState = {
 	fromStop: StopSearchResult | null;
 	toStop: StopSearchResult | null;
@@ -59,6 +51,131 @@ const initialFormState: FormState = {
 	notifyEnabled: false,
 };
 
+type NotifySettingsProps = {
+	/** 通知する出発目安の何分前（確定値） */
+	notifyBeforeMinutes: number;
+	/** 通知タイミングを永続化するハンドラ */
+	setNotifyBeforeMinutes: (value: number) => void;
+	/** フォーム送信中かどうか（設定ボタンの disabled 制御） */
+	submitting: boolean;
+	/** トグル処理中の経路 ID（設定ボタンの disabled 制御） */
+	togglingRouteId: number | null;
+	/** 通知パーミッション要求 */
+	onRequestNotificationPermission?: () => Promise<NotificationPermission>;
+	/** 現在の通知パーミッション */
+	notifyPermission?: NotificationPermission | "unsupported";
+};
+
+/**
+ * 通知タイミング設定 UI。
+ *
+ * showNotifySettings=true のときだけ親からマウントされる前提で、
+ * notifyBeforeMinutes / setNotifyBeforeMinutes を非 optional で受け取る。
+ * こうすることで内部フック useNotifyBeforeMinutesInput の useState 初期化子は
+ * 必ず確定値で走り、親側での `?? フォールバック` と `NOOP_SET_MINUTES` を
+ * 介した呼び出しによる「undefined→defined 遷移時にフォールバック値が
+ * 入力欄に取り残される」罠（PR #95 CodeRabbit 指摘）を構造的に排除する。
+ */
+function NotifySettings({
+	notifyBeforeMinutes,
+	setNotifyBeforeMinutes,
+	submitting,
+	togglingRouteId,
+	onRequestNotificationPermission,
+	notifyPermission,
+}: NotifySettingsProps) {
+	const {
+		inputValue,
+		setInputValue,
+		canCommit,
+		commit: internalCommit,
+	} = useNotifyBeforeMinutesInput(notifyBeforeMinutes, setNotifyBeforeMinutes);
+	const { showToast } = useToast();
+
+	/**
+	 * 通知分前入力の確定処理。Enter キー押下 / 設定ボタンクリック時に呼び出され、
+	 * 内部フックの commit に委譲する。設定ボタン側の disabled 条件と対称に
+	 * busy / validity を明示ガードし、Enter 経路でも誤トースト表示を防ぐ。
+	 */
+	const commitNotifyInput = () => {
+		if (submitting || togglingRouteId !== null) return;
+		if (!canCommit) return;
+		const result = internalCommit();
+		if (result.ok) {
+			showToast(
+				`発車の ${result.committedMinutes} 分前に通知するように設定しました`,
+				{ variant: "success" },
+			);
+			return;
+		}
+		const detail =
+			result.error instanceof Error
+				? result.error.message
+				: String(result.error);
+		showToast(`通知タイミングを設定できませんでした: ${detail}`, {
+			variant: "error",
+		});
+	};
+
+	return (
+		<div className="space-y-2 text-sm">
+			<p className="font-semibold text-base-content">
+				{`現在、出発 ${notifyBeforeMinutes} 分前に通知します`}
+			</p>
+			<div className="flex items-center gap-2">
+				<label
+					htmlFor="notify-before-minutes"
+					className="text-base-content/70 cursor-pointer"
+				>
+					通知タイミング
+				</label>
+				<input
+					id="notify-before-minutes"
+					type="number"
+					className="input input-bordered input-xs w-14"
+					min={NOTIFY_MIN_MINUTES}
+					max={NOTIFY_MAX_MINUTES}
+					step="1"
+					aria-describedby="notify-before-minutes-unit"
+					value={inputValue}
+					onChange={(e) => {
+						// 確定は Enter キー / 設定ボタンで行う（入力中の逐次 persist を防ぐ）。
+						// blur による自動確定は廃止（意図しない確定を避けるため）。
+						setInputValue(e.target.value);
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							commitNotifyInput();
+						}
+					}}
+				/>
+				<span id="notify-before-minutes-unit" className="text-base-content/70">
+					分前
+				</span>
+				<button
+					type="button"
+					className="btn btn-xs btn-primary"
+					onClick={commitNotifyInput}
+					disabled={!canCommit || submitting || togglingRouteId !== null}
+					aria-label="通知タイミングを設定"
+				>
+					設定
+				</button>
+				{notifyPermission === "default" && onRequestNotificationPermission && (
+					<button
+						type="button"
+						className="btn btn-xs btn-outline"
+						onClick={onRequestNotificationPermission}
+					>
+						通知を許可
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
 /** 経路登録・編集・削除を行うコンポーネント */
 export function RouteRegistration({
 	db,
@@ -72,30 +189,12 @@ export function RouteRegistration({
 	notifyBeforeMinutes,
 	setNotifyBeforeMinutes,
 }: RouteRegistrationProps) {
-	// 通知タイミング入力の確定値と編集中の値は本フックが同一スコープで保持する。
-	// Issue #93: 従来は App.tsx 側で useNotifyBeforeMinutesInput を呼び出し 4 つの
-	// props を受け渡していたため、キー入力のたびに AppContent 全体が再レンダされて
-	// いた。フックを消費側のコンポーネント内部に配置することで再レンダ範囲を
-	// RouteRegistration に局所化する。
-	//
-	// 通知タイミング UI は notifyBeforeMinutes / setNotifyBeforeMinutes の両方が
-	// 渡されているときのみ表示する。フックは条件付き呼び出しができないため、
-	// 未指定時はフォールバック値で呼び出すが、UI 自体が非表示のためユーザーから
-	// 到達することはない。
-	const {
-		inputValue: notifyInputValue,
-		setInputValue: setNotifyInputValue,
-		canCommit: canCommitNotifyInput,
-		commit: internalCommitNotifyInput,
-	} = useNotifyBeforeMinutesInput(
-		notifyBeforeMinutes ?? NOTIFY_DEFAULT_MINUTES,
-		setNotifyBeforeMinutes ?? NOOP_SET_MINUTES,
-	);
-
-	const showNotifySettings =
-		hasNotifyEnabledRoutes === true &&
-		notifyBeforeMinutes !== undefined &&
-		setNotifyBeforeMinutes !== undefined;
+	// Issue #93: 通知タイミング入力フックは RouteRegistration 内部に配置し
+	// AppContent 全体の再レンダを避ける。さらに PR #95 CodeRabbit 指摘対応で、
+	// notifyBeforeMinutes / setNotifyBeforeMinutes が両方揃ったときだけ
+	// 子コンポーネント NotifySettings をマウントし、その内部でフックを呼ぶ。
+	// これにより useState 初期化子は必ず確定値で走り、フォールバック値が
+	// 入力欄に残り続けるトラップを型レベルで排除できる。
 	const stopNameMap = useMemo(() => {
 		const ids = new Set<string>();
 		for (const route of routes) {
@@ -123,43 +222,6 @@ export function RouteRegistration({
 	const [togglingRouteId, setTogglingRouteId] = useState<number | null>(null);
 
 	const { showToast } = useToast();
-
-	/**
-	 * 通知分前入力の確定処理。
-	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、
-	 * 内部フック useNotifyBeforeMinutesInput の commit に委譲する。
-	 *
-	 * 設定ボタンは `disabled` 属性で
-	 *   (!canCommit || submitting || togglingRouteId !== null)
-	 * をガードしているが、Enter キー経路は無条件で呼び出されるため、
-	 * 呼び出し側でも同じ busy / validity 条件を明示ガードする。これは
-	 * 「busy 中は全確定経路を塞ぐ」という UI invariant と、
-	 * `invalid-or-unchanged` エラーがエラートーストとして誤表示されるのを
-	 * 防ぐためである。
-	 *
-	 * 入力値・確定値・ロールバックはフック側の責務で、ここでは commit 結果
-	 * に応じたトースト出力のみを担当する。
-	 */
-	const commitNotifyInput = () => {
-		// ボタン側の disabled 条件と対称に busy 状態を先にガードする
-		if (submitting || togglingRouteId !== null) return;
-		if (!canCommitNotifyInput) return;
-		const result = internalCommitNotifyInput();
-		if (result.ok) {
-			showToast(
-				`発車の ${result.committedMinutes} 分前に通知するように設定しました`,
-				{ variant: "success" },
-			);
-			return;
-		}
-		// 冒頭で canCommit=false をガード済みのため、ここへ来る失敗は
-		// 永続化失敗等の本物のエラーに限られる。エラートーストで通知する。
-		const detail =
-			result.error instanceof Error ? result.error.message : String(result.error);
-		showToast(`通知タイミングを設定できませんでした: ${detail}`, {
-			variant: "error",
-		});
-	};
 
 	const resetForm = useCallback(() => {
 		setForm(initialFormState);
@@ -383,71 +445,20 @@ export function RouteRegistration({
 								の経路でも出発前の通知は送信されません。ブラウザ設定で許可に変更してください。
 							</div>
 						)}
-						{showNotifySettings && (
-							<div className="space-y-2 text-sm">
-								<p className="font-semibold text-base-content">
-									{`現在、出発 ${notifyBeforeMinutes} 分前に通知します`}
-								</p>
-								<div className="flex items-center gap-2">
-									<label
-										htmlFor="notify-before-minutes"
-										className="text-base-content/70 cursor-pointer"
-									>
-										通知タイミング
-									</label>
-									<input
-										id="notify-before-minutes"
-										type="number"
-										className="input input-bordered input-xs w-14"
-										min={NOTIFY_MIN_MINUTES}
-										max={NOTIFY_MAX_MINUTES}
-										step="1"
-										aria-describedby="notify-before-minutes-unit"
-										value={notifyInputValue}
-										onChange={(e) => {
-											// 確定は Enter キー / 設定ボタンで行う（入力中の逐次 persist を防ぐ）。
-											// blur による自動確定は廃止（意図しない確定を避けるため）。
-											setNotifyInputValue(e.target.value);
-										}}
-										onKeyDown={(e) => {
-											if (e.key === "Enter") {
-												e.preventDefault();
-												commitNotifyInput();
-											}
-										}}
-									/>
-									<span
-										id="notify-before-minutes-unit"
-										className="text-base-content/70"
-									>
-										分前
-									</span>
-									<button
-										type="button"
-										className="btn btn-xs btn-primary"
-										onClick={commitNotifyInput}
-										disabled={
-											!canCommitNotifyInput ||
-											submitting ||
-											togglingRouteId !== null
-										}
-										aria-label="通知タイミングを設定"
-									>
-										設定
-									</button>
-									{notifyPermission === "default" &&
-										onRequestNotificationPermission && (
-											<button
-												type="button"
-												className="btn btn-xs btn-outline"
-												onClick={onRequestNotificationPermission}
-											>
-												通知を許可
-											</button>
-										)}
-								</div>
-							</div>
-						)}
+						{hasNotifyEnabledRoutes === true &&
+							notifyBeforeMinutes !== undefined &&
+							setNotifyBeforeMinutes !== undefined && (
+								<NotifySettings
+									notifyBeforeMinutes={notifyBeforeMinutes}
+									setNotifyBeforeMinutes={setNotifyBeforeMinutes}
+									submitting={submitting}
+									togglingRouteId={togglingRouteId}
+									onRequestNotificationPermission={
+										onRequestNotificationPermission
+									}
+									notifyPermission={notifyPermission}
+								/>
+							)}
 						<div className="overflow-x-auto">
 							<table className="table">
 								<thead>

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -103,7 +103,7 @@ function NotifySettings({
 		const result = internalCommit();
 		if (result.ok) {
 			showToast(
-				`発車の ${result.committedMinutes} 分前に通知するように設定しました`,
+				`出発の ${result.committedMinutes} 分前に通知するように設定しました`,
 				{ variant: "success" },
 			);
 			return;

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import type { Database } from "sql.js";
 import {
+	NOTIFY_DEFAULT_MINUTES,
 	NOTIFY_MAX_MINUTES,
 	NOTIFY_MIN_MINUTES,
 } from "../constants/notification";
-import type { NotifyInputCommitResult } from "../hooks/useNotifyBeforeMinutesInput";
+import { useNotifyBeforeMinutesInput } from "../hooks/useNotifyBeforeMinutesInput";
 import { useToast } from "../hooks/useToast";
 import { type StopSearchResult, getStopName } from "../lib/stop-search";
 import type { RegisteredRouteEntry, RouteEntry } from "../types/route-entry";
@@ -29,15 +30,20 @@ type RouteRegistrationProps = {
 	hasNotifyEnabledRoutes?: boolean;
 	/** 通知する出発目安の何分前（確定値／表示用、undefined のとき通知タイミング UI を非表示） */
 	notifyBeforeMinutes?: number;
-	/** 通知タイミングの入力中文字列（制御コンポーネント） */
-	notifyInputValue?: string;
-	/** 入力値変更ハンドラ */
-	onNotifyInputChange?: (value: string) => void;
-	/** 入力値が有効かつ未保存の変更を含むかどうか */
-	canCommitNotifyInput?: boolean;
-	/** 入力値の確定ハンドラ。成功/失敗と確定後の値を返す */
-	onCommitNotifyInput?: () => NotifyInputCommitResult;
+	/**
+	 * 通知タイミングを永続化するハンドラ。undefined のときは通知タイミング UI を非表示にする。
+	 * 入力値の一時保持・バリデーション・確定処理は本コンポーネント内部の
+	 * useNotifyBeforeMinutesInput が担い、確定成功時のみ本ハンドラを呼び出す。
+	 */
+	setNotifyBeforeMinutes?: (value: number) => void;
 };
+
+/**
+ * setNotifyBeforeMinutes 未指定時のフォールバック。useState 初期化子が一度だけ
+ * この参照を見るためモジュールスコープで定義して安定参照を提供する。通知タイミング
+ * UI は表示条件で非表示化されるため、この no-op が実際に呼ばれることはない。
+ */
+const NOOP_SET_MINUTES = (_value: number) => {};
 
 type FormState = {
 	fromStop: StopSearchResult | null;
@@ -64,11 +70,32 @@ export function RouteRegistration({
 	notifyPermission,
 	hasNotifyEnabledRoutes,
 	notifyBeforeMinutes,
-	notifyInputValue,
-	onNotifyInputChange,
-	canCommitNotifyInput,
-	onCommitNotifyInput,
+	setNotifyBeforeMinutes,
 }: RouteRegistrationProps) {
+	// 通知タイミング入力の確定値と編集中の値は本フックが同一スコープで保持する。
+	// Issue #93: 従来は App.tsx 側で useNotifyBeforeMinutesInput を呼び出し 4 つの
+	// props を受け渡していたため、キー入力のたびに AppContent 全体が再レンダされて
+	// いた。フックを消費側のコンポーネント内部に配置することで再レンダ範囲を
+	// RouteRegistration に局所化する。
+	//
+	// 通知タイミング UI は notifyBeforeMinutes / setNotifyBeforeMinutes の両方が
+	// 渡されているときのみ表示する。フックは条件付き呼び出しができないため、
+	// 未指定時はフォールバック値で呼び出すが、UI 自体が非表示のためユーザーから
+	// 到達することはない。
+	const {
+		inputValue: notifyInputValue,
+		setInputValue: setNotifyInputValue,
+		canCommit: canCommitNotifyInput,
+		commit: internalCommitNotifyInput,
+	} = useNotifyBeforeMinutesInput(
+		notifyBeforeMinutes ?? NOTIFY_DEFAULT_MINUTES,
+		setNotifyBeforeMinutes ?? NOOP_SET_MINUTES,
+	);
+
+	const showNotifySettings =
+		hasNotifyEnabledRoutes === true &&
+		notifyBeforeMinutes !== undefined &&
+		setNotifyBeforeMinutes !== undefined;
 	const stopNameMap = useMemo(() => {
 		const ids = new Set<string>();
 		for (const route of routes) {
@@ -100,7 +127,7 @@ export function RouteRegistration({
 	/**
 	 * 通知分前入力の確定処理。
 	 * Enter キー押下 / 設定ボタンクリック時に呼び出され、
-	 * onCommitNotifyInput（親フックの commit）に委譲する。
+	 * 内部フック useNotifyBeforeMinutesInput の commit に委譲する。
 	 *
 	 * 設定ボタンは `disabled` 属性で
 	 *   (!canCommit || submitting || togglingRouteId !== null)
@@ -110,16 +137,14 @@ export function RouteRegistration({
 	 * `invalid-or-unchanged` エラーがエラートーストとして誤表示されるのを
 	 * 防ぐためである。
 	 *
-	 * コールバック未指定時は「設定しました」トーストの誤表示を防ぐため
-	 * 明示的に no-op。入力値・確定値・ロールバックは親フック側の責務で、
-	 * ここでは commit 結果に応じたトースト出力のみを担当する。
+	 * 入力値・確定値・ロールバックはフック側の責務で、ここでは commit 結果
+	 * に応じたトースト出力のみを担当する。
 	 */
 	const commitNotifyInput = () => {
 		// ボタン側の disabled 条件と対称に busy 状態を先にガードする
 		if (submitting || togglingRouteId !== null) return;
 		if (!canCommitNotifyInput) return;
-		if (!onCommitNotifyInput) return;
-		const result = onCommitNotifyInput();
+		const result = internalCommitNotifyInput();
 		if (result.ok) {
 			showToast(
 				`発車の ${result.committedMinutes} 分前に通知するように設定しました`,
@@ -358,7 +383,7 @@ export function RouteRegistration({
 								の経路でも出発前の通知は送信されません。ブラウザ設定で許可に変更してください。
 							</div>
 						)}
-						{hasNotifyEnabledRoutes && notifyBeforeMinutes !== undefined && (
+						{showNotifySettings && (
 							<div className="space-y-2 text-sm">
 								<p className="font-semibold text-base-content">
 									{`現在、出発 ${notifyBeforeMinutes} 分前に通知します`}
@@ -378,11 +403,11 @@ export function RouteRegistration({
 										max={NOTIFY_MAX_MINUTES}
 										step="1"
 										aria-describedby="notify-before-minutes-unit"
-										value={notifyInputValue ?? ""}
+										value={notifyInputValue}
 										onChange={(e) => {
 											// 確定は Enter キー / 設定ボタンで行う（入力中の逐次 persist を防ぐ）。
 											// blur による自動確定は廃止（意図しない確定を避けるため）。
-											onNotifyInputChange?.(e.target.value);
+											setNotifyInputValue(e.target.value);
 										}}
 										onKeyDown={(e) => {
 											if (e.key === "Enter") {
@@ -402,7 +427,7 @@ export function RouteRegistration({
 										className="btn btn-xs btn-primary"
 										onClick={commitNotifyInput}
 										disabled={
-											!(canCommitNotifyInput ?? false) ||
+											!canCommitNotifyInput ||
 											submitting ||
 											togglingRouteId !== null
 										}

--- a/src/hooks/useNotifyBeforeMinutesInput.ts
+++ b/src/hooks/useNotifyBeforeMinutesInput.ts
@@ -3,7 +3,6 @@ import {
 	NOTIFY_MAX_MINUTES,
 	NOTIFY_MIN_MINUTES,
 } from "../constants/notification";
-import { useNotificationSettings } from "./useNotificationSettings";
 
 /**
  * commit() の戻り値。
@@ -23,14 +22,22 @@ export type NotifyInputCommitResult =
  * 場合に編集途中の値を破壊する典型的なアンチパターンである
  * （Issue #89）。
  *
- * 本フックは確定値（useNotificationSettings の minutes）と
- * 編集中の値（inputValue）を同一スコープで管理し、
- * 編集開始後は minutes が変わっても inputValue が書き換えられない
- * 性質を保証する。RouteRegistration は純粋な制御コンポーネントとなり
+ * 本フックは確定値（引数 minutes）と編集中の値（inputValue）を
+ * 同一スコープで管理し、編集開始後は minutes が変わっても inputValue が
+ * 書き換えられない性質を保証する（useState の初期化子は初回マウント時のみ
+ * 評価されるため）。RouteRegistration は純粋な制御コンポーネントとなり
  * useEffect 同期が不要になる。
+ *
+ * Issue #93: 本フックは従来 `useNotificationSettings()` を内部で呼び出して
+ * いたが、それにより useNotifyBeforeMinutesInput を呼ぶコンポーネント全体が
+ * minutes 更新で再レンダリングされてしまっていた。UI 上は RouteRegistration
+ * のみが minutes を必要とするため、呼び出し側から (minutes, setMinutes) を
+ * 受け取る形に変更し、再レンダの局所化を実現する。
  */
-export function useNotifyBeforeMinutesInput() {
-	const { minutes, setMinutes } = useNotificationSettings();
+export function useNotifyBeforeMinutesInput(
+	minutes: number,
+	setMinutes: (value: number) => void,
+) {
 	const [inputValue, setInputValue] = useState<string>(() => String(minutes));
 
 	const parsed = Number(inputValue);

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -7,6 +7,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { type ReactElement, useState } from "react";
 import initSqlJs from "sql.js";
+import type { Database } from "sql.js";
 import {
 	afterEach,
 	beforeAll,
@@ -16,7 +17,6 @@ import {
 	it,
 	vi,
 } from "vitest";
-import type { Database } from "sql.js";
 import { RouteRegistration } from "../src/components/RouteRegistration";
 import { ToastContainer } from "../src/components/Toast";
 import { ToastProvider } from "../src/hooks/useToast";
@@ -121,7 +121,9 @@ function renderComponent(routes: RegisteredRouteEntry[] = []) {
 function NotifyHarness(props: {
 	db: Database;
 	routes: RegisteredRouteEntry[];
-	onAdd: (entry: Omit<import("../src/types/route-entry").RouteEntry, "id">) => Promise<number>;
+	onAdd: (
+		entry: Omit<import("../src/types/route-entry").RouteEntry, "id">,
+	) => Promise<number>;
 	onUpdate: (entry: RegisteredRouteEntry) => Promise<void>;
 	onDelete: (id: number) => Promise<void>;
 	onRequestNotificationPermission?: () => Promise<NotificationPermission>;
@@ -131,11 +133,7 @@ function NotifyHarness(props: {
 	/** commit 成功時に minutes 引数で呼ばれる。throw すると rollback される */
 	onCommitSpy?: (minutes: number) => void;
 }) {
-	const {
-		initialMinutes = 5,
-		onCommitSpy,
-		...componentProps
-	} = props;
+	const { initialMinutes = 5, onCommitSpy, ...componentProps } = props;
 	const [minutes, setMinutes] = useState(initialMinutes);
 
 	const setNotifyBeforeMinutes = (value: number) => {
@@ -1546,6 +1544,61 @@ describe("RouteRegistration コンポーネント", () => {
 				await screen.findByText(/通知タイミング.*設定できませんでした/),
 			).toBeInTheDocument();
 			expect(input).toHaveValue(5);
+		});
+
+		it("初回マウント時に notifyBeforeMinutes=undefined でも、後から確定値が流入したときに入力欄が確定値に一致する", () => {
+			// CodeRabbit 指摘（#95）のシナリオ:
+			// useNotifyBeforeMinutesInput は useState 初期化子でマウント時の minutes を
+			// 一度だけ捕捉する。RouteRegistration が `?? NOTIFY_DEFAULT_MINUTES` で
+			// フォールバックしたまま無条件にフックを呼ぶ構造だと、初回 undefined で
+			// 初期化されたフック内の inputValue がフォールバック値 5 のまま残り、
+			// 後から確定値 8 が流入して UI が表示されたときに表示ラベルは 8 なのに
+			// 入力欄は 5 のままという不整合が生じる。
+			// 通知 UI を別コンポーネントに切り出し showNotifySettings=true のときだけ
+			// マウントする構造にすれば、フックの初期化子は確定値で走るため入力欄も
+			// 表示も 8 に一致する。
+			function UndefinedToDefinedChanger() {
+				const [minutes, setMinutes] = useState<number | undefined>(undefined);
+				const setNotifyBeforeMinutes =
+					minutes === undefined
+						? undefined
+						: (value: number) => setMinutes(value);
+				return (
+					<>
+						<button
+							type="button"
+							onClick={() => setMinutes(8)}
+							data-testid="force-define-minutes"
+						>
+							確定値を 8 にセット
+						</button>
+						<RouteRegistration
+							db={db}
+							routes={notifyEnabledRoutes}
+							{...baseHandlers()}
+							hasNotifyEnabledRoutes={true}
+							notifyBeforeMinutes={minutes}
+							setNotifyBeforeMinutes={setNotifyBeforeMinutes}
+						/>
+					</>
+				);
+			}
+			render(<UndefinedToDefinedChanger />);
+
+			// 初回は通知タイミング UI 非表示（notifyBeforeMinutes=undefined）
+			expect(
+				screen.queryByRole("spinbutton", { name: "通知タイミング" }),
+			).not.toBeInTheDocument();
+
+			// 親が確定値 8 と永続化ハンドラを後から渡す
+			fireEvent.click(screen.getByTestId("force-define-minutes"));
+
+			// UI が表示され、確定値表示も入力欄も 8 に一致する
+			expect(
+				screen.getByText(/現在、出発\s*8\s*分前に通知します/),
+			).toBeInTheDocument();
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			expect(input).toHaveValue(8);
 		});
 
 		it("外部から notifyBeforeMinutes が更新されても入力中の値が破壊されない（Issue #89）", () => {

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -19,7 +19,6 @@ import {
 import type { Database } from "sql.js";
 import { RouteRegistration } from "../src/components/RouteRegistration";
 import { ToastContainer } from "../src/components/Toast";
-import type { NotifyInputCommitResult } from "../src/hooks/useNotifyBeforeMinutesInput";
 import { ToastProvider } from "../src/hooks/useToast";
 import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
 import type { GtfsData } from "../src/types/gtfs";
@@ -110,13 +109,14 @@ function renderComponent(routes: RegisteredRouteEntry[] = []) {
 
 /**
  * 通知タイミング UI の対話系テスト向けハーネス。
- * useNotifyBeforeMinutesInput の振る舞いを等価に再現しつつ、
- * commit 成功時のスパイ注入・失敗時の挙動確認を可能にする。
+ * 内部で minutes を state として保持し、setNotifyBeforeMinutes に
+ * onCommitSpy を挟むことで commit 成功時の spy 検証・throw による
+ * rollback 検証を可能にする。
  *
- * 実フック (`useNotifyBeforeMinutesInput`) と異なり localStorage には
- * 触れず、confirmation 専用のインメモリ状態だけで動作する。これにより
- * テスト間での localStorage 漏れを避けつつ、確定値・入力値の同一スコープ
- * 管理による「入力中の外部更新保護」の振る舞いを再現できる。
+ * 本物の useNotificationSettings と異なり localStorage には触れず、
+ * インメモリ状態のみで動作する。RouteRegistration 内部の
+ * useNotifyBeforeMinutesInput がそのまま動くため、入力中の文字列
+ * state や canCommit 判定は本物と同一の実装で検証される。
  */
 function NotifyHarness(props: {
 	db: Database;
@@ -128,7 +128,7 @@ function NotifyHarness(props: {
 	notifyPermission?: NotificationPermission | "unsupported";
 	hasNotifyEnabledRoutes?: boolean;
 	initialMinutes?: number;
-	/** commit 時に minutes 引数で呼ばれる。throw すると rollback される */
+	/** commit 成功時に minutes 引数で呼ばれる。throw すると rollback される */
 	onCommitSpy?: (minutes: number) => void;
 }) {
 	const {
@@ -137,38 +137,20 @@ function NotifyHarness(props: {
 		...componentProps
 	} = props;
 	const [minutes, setMinutes] = useState(initialMinutes);
-	const [inputValue, setInputValue] = useState(String(initialMinutes));
 
-	const parsed = Number(inputValue);
-	const isValid =
-		inputValue.trim() !== "" &&
-		Number.isInteger(parsed) &&
-		parsed >= 1 &&
-		parsed <= 60;
-	const canCommit = isValid && parsed !== minutes;
-
-	const commit = (): NotifyInputCommitResult => {
-		if (!canCommit) {
-			return { ok: false, error: new Error("invalid-or-unchanged") };
-		}
-		try {
-			onCommitSpy?.(parsed);
-			setMinutes(parsed);
-			return { ok: true, committedMinutes: parsed };
-		} catch (err) {
-			setInputValue(String(minutes));
-			return { ok: false, error: err };
-		}
+	const setNotifyBeforeMinutes = (value: number) => {
+		// onCommitSpy が throw すれば setMinutes に到達せず、
+		// RouteRegistration 内部の useNotifyBeforeMinutesInput が
+		// 入力値を元の minutes にロールバックする。
+		onCommitSpy?.(value);
+		setMinutes(value);
 	};
 
 	return (
 		<RouteRegistration
 			{...componentProps}
 			notifyBeforeMinutes={minutes}
-			notifyInputValue={inputValue}
-			onNotifyInputChange={setInputValue}
-			canCommitNotifyInput={canCommit}
-			onCommitNotifyInput={commit}
+			setNotifyBeforeMinutes={setNotifyBeforeMinutes}
 		/>
 	);
 }
@@ -1181,10 +1163,12 @@ describe("RouteRegistration コンポーネント", () => {
 			).toBeInTheDocument();
 		});
 
-		it("onCommitNotifyInput が未指定の場合は成功トーストが表示されない", async () => {
-			// 親が commit ハンドラを渡していないとき（例えば feature flag OFF 等）に
-			// 「設定しました」トーストが誤って表示されるとユーザーに未実施の操作が
-			// 完了したかのような誤情報を伝えてしまう。ハンドラ未指定時は no-op すべき。
+		it("setNotifyBeforeMinutes が未指定の場合は通知タイミング UI が表示されない", () => {
+			// 親が永続化ハンドラを渡していないとき（例えば feature flag OFF 等）に
+			// 通知タイミング入力 UI を描画してしまうと、入力はできるが保存されない
+			// という矛盾した挙動になり、確定後に「設定しました」トーストが出ても
+			// 実際には何も永続化されていないという誤情報をユーザーに伝えてしまう。
+			// そのため setNotifyBeforeMinutes 未指定時は UI 自体を非表示にする。
 			render(
 				<RouteRegistration
 					db={db}
@@ -1192,19 +1176,16 @@ describe("RouteRegistration コンポーネント", () => {
 					{...baseHandlers()}
 					hasNotifyEnabledRoutes={true}
 					notifyBeforeMinutes={5}
-					notifyInputValue="5"
-					onNotifyInputChange={() => {}}
-					canCommitNotifyInput={true}
-					// onCommitNotifyInput を意図的に渡さない
+					// setNotifyBeforeMinutes を意図的に渡さない
 				/>,
 			);
-			await userEvent.click(
-				screen.getByRole("button", { name: "通知タイミングを設定" }),
-			);
-			// 成功トーストが出てはならない
 			expect(
-				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+				screen.queryByRole("spinbutton", { name: "通知タイミング" }),
 			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "通知タイミングを設定" }),
+			).not.toBeInTheDocument();
+			expect(screen.queryByText(/現在、出発/)).not.toBeInTheDocument();
 		});
 
 		it("blur では commit が呼ばれない（確定は Enter / 設定ボタンのみ）", () => {
@@ -1571,12 +1552,11 @@ describe("RouteRegistration コンポーネント", () => {
 			// 従来 RouteRegistration は notifyBeforeMinutes の変化を useEffect で
 			// 内部 state に同期していたため、ユーザーが編集中に親の確定値が
 			// 変わると入力途中の値が上書きされるアンチパターンが存在した。
-			// リフトアップ後は制御コンポーネントとなり、親が notifyInputValue を
-			// 明示的に変更しない限り入力は保持される。
+			// Issue #93 以降は内部フック useNotifyBeforeMinutesInput の useState
+			// 初期化子がマウント時にのみ minutes を参照するため、外部から
+			// notifyBeforeMinutes が変わっても編集中の入力値は保持される。
 			function ExternalMinutesChanger() {
 				const [externalMinutes, setExternalMinutes] = useState(5);
-				// 入力値だけはローカル維持（親は inputValue を確定値と独立に扱う）
-				const [inputValue, setInputValue] = useState("5");
 				return (
 					<>
 						<button
@@ -1592,13 +1572,7 @@ describe("RouteRegistration コンポーネント", () => {
 							{...baseHandlers()}
 							hasNotifyEnabledRoutes={true}
 							notifyBeforeMinutes={externalMinutes}
-							notifyInputValue={inputValue}
-							onNotifyInputChange={setInputValue}
-							canCommitNotifyInput={false}
-							onCommitNotifyInput={() => ({
-								ok: true,
-								committedMinutes: Number(inputValue),
-							})}
+							setNotifyBeforeMinutes={setExternalMinutes}
 						/>
 					</>
 				);

--- a/test/useNotifyBeforeMinutesInput.test.ts
+++ b/test/useNotifyBeforeMinutesInput.test.ts
@@ -1,8 +1,20 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNotificationSettings } from "../src/hooks/useNotificationSettings";
 import { useNotifyBeforeMinutesInput } from "../src/hooks/useNotifyBeforeMinutesInput";
 
 const STORAGE_KEY = "notify-before-minutes";
+
+/**
+ * フックの呼び出し側が useNotificationSettings の minutes/setMinutes を
+ * そのまま渡す実運用の形を再現するためのラッパ。
+ * フック自身は永続化責務を持たないが、テストでは永続化まで通した
+ * 結合テスト相当の検証を維持するためにこの形を採用する。
+ */
+function useWrapper() {
+	const { minutes, setMinutes } = useNotificationSettings();
+	return useNotifyBeforeMinutesInput(minutes, setMinutes);
+}
 
 beforeEach(() => {
 	localStorage.clear();
@@ -16,13 +28,13 @@ afterEach(() => {
 describe("useNotifyBeforeMinutesInput", () => {
 	it("初期状態で inputValue は minutes の文字列表現と一致する", () => {
 		localStorage.setItem(STORAGE_KEY, "8");
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		expect(result.current.minutes).toBe(8);
 		expect(result.current.inputValue).toBe("8");
 	});
 
 	it("setInputValue は inputValue のみを変更し minutes は変わらない", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		const initialMinutes = result.current.minutes;
 
 		act(() => {
@@ -34,7 +46,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("有効な変更済みの値に対して canCommit が true になる", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		// デフォルト minutes=5
 		act(() => {
 			result.current.setInputValue("15");
@@ -43,13 +55,13 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("現在値と同じ値のとき canCommit は false", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		// 初期 inputValue=5, minutes=5
 		expect(result.current.canCommit).toBe(false);
 	});
 
 	it("範囲外（0 以下）の入力では canCommit は false", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		act(() => {
 			result.current.setInputValue("0");
 		});
@@ -57,7 +69,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("範囲外（60 超）の入力では canCommit は false", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		act(() => {
 			result.current.setInputValue("61");
 		});
@@ -65,7 +77,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("小数の入力では canCommit は false", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		act(() => {
 			result.current.setInputValue("5.5");
 		});
@@ -73,7 +85,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("空文字の入力では canCommit は false", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		act(() => {
 			result.current.setInputValue("");
 		});
@@ -81,7 +93,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("commit() は有効な入力を minutes に反映し { ok: true } を返す", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 
 		act(() => {
 			result.current.setInputValue("20");
@@ -102,7 +114,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("commit() で setMinutes が throw したら inputValue は元の minutes にロールバックされる", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		const initialMinutes = result.current.minutes;
 
 		act(() => {
@@ -138,7 +150,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 	});
 
 	it("canCommit=false の状態で commit() を呼んでも minutes は変わらない", () => {
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 		const initialMinutes = result.current.minutes;
 
 		// 範囲外の値
@@ -157,7 +169,7 @@ describe("useNotifyBeforeMinutesInput", () => {
 		// Issue #89 の核心: 入力中の値が外部の minutes 変化で破壊されないこと。
 		// このフックでは入力状態を minutes と同じスコープで保持するため、
 		// 一度 commit した後に再度入力を始めても入力値が勝手にリセットされない。
-		const { result } = renderHook(() => useNotifyBeforeMinutesInput());
+		const { result } = renderHook(() => useWrapper());
 
 		act(() => {
 			result.current.setInputValue("10");
@@ -175,5 +187,31 @@ describe("useNotifyBeforeMinutesInput", () => {
 		// この時点では minutes は 10 のままで、inputValue だけが 3 になる
 		expect(result.current.minutes).toBe(10);
 		expect(result.current.inputValue).toBe("3");
+	});
+
+	it("外部 minutes が編集開始後に変化しても inputValue を破壊しない", () => {
+		// Issue #89 回帰防止 + #93 リフトアップ後の追加保証:
+		// 呼び出し側で minutes を再評価しても、フックは useState 初期化子で
+		// マウント時のみ minutes を参照するため、編集中の inputValue は保持される。
+		const { result, rerender } = renderHook(
+			({ minutes }: { minutes: number }) => {
+				const setMinutes = vi.fn();
+				return useNotifyBeforeMinutesInput(minutes, setMinutes);
+			},
+			{ initialProps: { minutes: 5 } },
+		);
+
+		act(() => {
+			result.current.setInputValue("12");
+		});
+		expect(result.current.inputValue).toBe("12");
+
+		// 外部から minutes を 20 に変更（他タブ同期などを想定）
+		rerender({ minutes: 20 });
+
+		// inputValue は編集中の "12" のまま保持されなければならない
+		expect(result.current.inputValue).toBe("12");
+		// minutes は rerender 後の値を反映する
+		expect(result.current.minutes).toBe(20);
 	});
 });


### PR DESCRIPTION
## 概要

Issue #93 への対応。`useNotifyBeforeMinutesInput` を `AppContent` で呼び出していたため、入力欄のキー入力ごとに `AppContent` 全体（`MapView` / `DepartureBoard` 等を含む）が再レンダリングされていた。フックを実際の消費者である `RouteRegistration` 内部へ移設し、再レンダ範囲を局所化する。

PR #92 のレビュー（gemini-code-assist `discussion_r3104560426`）で指摘されたパフォーマンス上の regression に対する本対応であり、#89 の props → state 同期廃止で得た正しさを維持したまま再レンダ範囲を縮小する。

## 設計方針（PR #92 コメント返信で提示した A 案）

- フックを消費側コンポーネント（`RouteRegistration`）の内部に配置する
- `useNotifyBeforeMinutesInput` は `(minutes, setMinutes)` を引数で受け取る形に変更し、永続化責務を持たない純粋な入力 state 管理フックとする
- `RouteRegistration` の通知関連 props を 4 つ (`notifyInputValue` / `onNotifyInputChange` / `canCommitNotifyInput` / `onCommitNotifyInput`) から 1 つ (`setNotifyBeforeMinutes`) に集約
- `setNotifyBeforeMinutes` が未指定のときは通知タイミング UI を非表示にすることで、入力できるが永続化されないという矛盾挙動を排除

### なぜ A 案か（B 案 `React.memo` を採用しなかった理由）

- A 案はデータフローを 1 本化して props 面を縮小する方向の変更であり、メンテナンス性が上がる
- B 案は `React.memo` + 全コールバックの `useCallback` 化で referential stability tax を払い続ける必要があり、`AppContent` 配下すべての子要素に波及してメンテナンス負荷が増える
- 工数よりコード複雑性解消・メンテナンス性を優先するという方針に従って A 案を採用

## 主な変更

- ` src/hooks/useNotifyBeforeMinutesInput.ts `: シグネチャを `(minutes, setMinutes)` に変更。内部で `useNotificationSettings` を呼ぶのをやめ、入力文字列 state のみを責務とする。
- ` src/components/RouteRegistration.tsx `: 通知関連 props を 4 つから 1 つ (`setNotifyBeforeMinutes`) に削減。内部で `useNotifyBeforeMinutesInput` を呼ぶ。通知タイミング UI 表示条件に `setNotifyBeforeMinutes !== undefined` を追加。
- ` src/App.tsx `: `useNotificationSettings` を直接呼び、`minutes` / `setMinutes` のみを `RouteRegistration` に渡す形へ戻す。
- ` test/useNotifyBeforeMinutesInput.test.ts `: `(minutes, setMinutes)` を渡す形へ書き換え。外部 minutes 変更時の入力値保護テスト（Issue #89 リフトアップ後の追加保証）を追加。
- ` test/RouteRegistration.test.tsx `: `NotifyHarness` を `setNotifyBeforeMinutes` に `onCommitSpy` を挟むラッパーへ簡素化し、`RouteRegistration` 内部フックの実挙動をそのまま検証する形に変更。

## 検証

- [x] `npm run test` 全 418 件 PASS
- [x] `npm run build` 型チェック + ビルド PASS
- [ ] ブラウザで通知タイミング入力中の再レンダ範囲縮小を確認（DevTools Profiler 等）
- [ ] 通知タイミング確定後の `localStorage` 永続化と表示反映を確認
- [ ] Issue #89 回帰防止（外部からの minutes 更新で入力値が破壊されないこと）を確認

## 関連

- Close #93
- 前提: PR #92 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 通知タイミング設定の内部状態管理を再構成し、親コンポーネントは値の読み取りと更新用の setter のみを渡すように変更しました。入力の取り扱いとコミット操作は該当コンポーネントへ移譲されています。
* **Tests**
  * 振る舞いを反映するようテストを更新／追加し、UIの表示条件や入力・永続化の回帰を検証するケースを整備しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->