### PR TITLE
feat: 直通便で到達不能な乗降車バス停の組み合わせを選択肢から除外 (#90)

### DIFF
--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -194,8 +194,14 @@ export function RouteRegistration({
 			// Issue #90: 直通便で到達不能な組み合わせを弾く。
 			// 兄弟バス停（上下線・事業者違い）まで展開して判定することで、
 			// 選択肢として見えている「同一物理停留所」からの直通便を網羅する。
-			const fromIds = getSiblingStopIds(db, form.fromStop.stop_id);
-			const toIds = getSiblingStopIds(db, form.toStop.stop_id);
+			// 兄弟展開結果は親側で useMemo 済みのため、送信時は再計算せず
+			// メモ化値を再利用する（gemini-code-assist #96 指摘）。
+			// `??` を使うのは `string[] | null` に対して空配列を falsy 扱いしない
+			// ためで、理屈上フォールバックへは到達しないが型安全のガードとして置く。
+			const fromIds =
+				fromStopSiblings ?? getSiblingStopIds(db, form.fromStop.stop_id);
+			const toIds =
+				toStopSiblings ?? getSiblingStopIds(db, form.toStop.stop_id);
 			if (!isReachable(db, fromIds, toIds)) {
 				setErrorMessage(
 					"選択したバス停間に直通便がありません。別の組み合わせを選んでください",
@@ -250,6 +256,8 @@ export function RouteRegistration({
 		[
 			db,
 			form,
+			fromStopSiblings,
+			toStopSiblings,
 			editingId,
 			onAdd,
 			onUpdate,

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -6,7 +6,12 @@ import {
 } from "../constants/notification";
 import type { NotifyInputCommitResult } from "../hooks/useNotifyBeforeMinutesInput";
 import { useToast } from "../hooks/useToast";
-import { type StopSearchResult, getStopName } from "../lib/stop-search";
+import { isReachable } from "../lib/stop-reachability";
+import {
+	type StopSearchResult,
+	getSiblingStopIds,
+	getStopName,
+} from "../lib/stop-search";
 import type { RegisteredRouteEntry, RouteEntry } from "../types/route-entry";
 import { StopSearch } from "./StopSearch";
 
@@ -90,6 +95,28 @@ export function RouteRegistration({
 	const [editingId, setEditingId] = useState<number | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	// Issue #90: 選択済みの相手バス停から、StopSearch に渡す到達可能性フィルタを
+	// 構築する。兄弟バス停（同名近距離・上下線など）まで展開した stop_id 群を
+	// 与えることで、事業者違い・方向違いでも直通便が存在すれば候補として残す。
+	const fromStopSiblings = useMemo(
+		() => (form.fromStop ? getSiblingStopIds(db, form.fromStop.stop_id) : null),
+		[db, form.fromStop],
+	);
+	const toStopSiblings = useMemo(
+		() => (form.toStop ? getSiblingStopIds(db, form.toStop.stop_id) : null),
+		[db, form.toStop],
+	);
+	const toStopFilter = useMemo(
+		() =>
+			fromStopSiblings ? { reachableFromOrigin: fromStopSiblings } : undefined,
+		[fromStopSiblings],
+	);
+	const fromStopFilter = useMemo(
+		() =>
+			toStopSiblings ? { reachableToDestination: toStopSiblings } : undefined,
+		[toStopSiblings],
+	);
 	// トグル処理中の経路 ID。submitting と分離することで、フォーム側の
 	// 「登録」ボタンが通知 ON/OFF のたびに「保存中...」へ切り替わるなどの
 	// 表示揺れを防ぐ。トグル処理は複数同時実行させないため null | number で十分。
@@ -130,7 +157,9 @@ export function RouteRegistration({
 		// 冒頭で canCommit=false をガード済みのため、ここへ来る失敗は
 		// 永続化失敗等の本物のエラーに限られる。エラートーストで通知する。
 		const detail =
-			result.error instanceof Error ? result.error.message : String(result.error);
+			result.error instanceof Error
+				? result.error.message
+				: String(result.error);
 		showToast(`通知タイミングを設定できませんでした: ${detail}`, {
 			variant: "error",
 		});
@@ -161,6 +190,19 @@ export function RouteRegistration({
 				);
 				return;
 			}
+
+			// Issue #90: 直通便で到達不能な組み合わせを弾く。
+			// 兄弟バス停（上下線・事業者違い）まで展開して判定することで、
+			// 選択肢として見えている「同一物理停留所」からの直通便を網羅する。
+			const fromIds = getSiblingStopIds(db, form.fromStop.stop_id);
+			const toIds = getSiblingStopIds(db, form.toStop.stop_id);
+			if (!isReachable(db, fromIds, toIds)) {
+				setErrorMessage(
+					"選択したバス停間に直通便がありません。別の組み合わせを選んでください",
+				);
+				return;
+			}
+
 			const DEFAULT_WALK_MINUTES = 10;
 			const walkMinutes =
 				form.walkMinutes === ""
@@ -206,6 +248,7 @@ export function RouteRegistration({
 			}
 		},
 		[
+			db,
 			form,
 			editingId,
 			onAdd,
@@ -275,6 +318,7 @@ export function RouteRegistration({
 								setForm((prev) => ({ ...prev, fromStop: stop }))
 							}
 							selectedStop={form.fromStop}
+							reachabilityFilter={fromStopFilter}
 						/>
 						<StopSearch
 							db={db}
@@ -283,6 +327,7 @@ export function RouteRegistration({
 								setForm((prev) => ({ ...prev, toStop: stop }))
 							}
 							selectedStop={form.toStop}
+							reachabilityFilter={toStopFilter}
 						/>
 					</div>
 					<div className="form-control w-full max-w-xs">

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import type { Database } from "sql.js";
 import { getAgencyColor } from "../lib/agency-colors";
 import {
@@ -37,50 +44,39 @@ export function StopSearch({
 }: StopSearchProps) {
 	const id = useId();
 	const [query, setQuery] = useState(selectedStop?.stop_name ?? "");
-	const [results, setResults] = useState<StopSearchResult[]>([]);
 	const [isOpen, setIsOpen] = useState(false);
 	const [activeIndex, setActiveIndex] = useState(-1);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
+
+	// 検索結果は state ではなく派生値とする（gemini-code-assist #96 指摘）。
+	// `db` / `query` / `reachabilityFilter` が唯一の入力であるという依存関係を
+	// 型レベルで可視化し、useEffect による props → state 同期アンチパターンを排除する。
+	// ドロップダウンの開閉は独立した UI 状態として `isOpen` で制御する。
+	const results = useMemo<StopSearchResult[]>(() => {
+		if (query.trim() === "") return [];
+		return searchStops(db, query, undefined, reachabilityFilter);
+	}, [db, query, reachabilityFilter]);
 
 	// 外部から selectedStop が変更された場合に入力欄を同期する
 	useEffect(() => {
 		setQuery(selectedStop?.stop_name ?? "");
 	}, [selectedStop]);
 
-	const handleSearch = useCallback(
-		(value: string) => {
-			setQuery(value);
-			setActiveIndex(-1);
-			if (value.trim() === "") {
-				setResults([]);
-				setIsOpen(false);
-				return;
-			}
-			const found = searchStops(db, value, undefined, reachabilityFilter);
-			setResults(found);
-			setIsOpen(found.length > 0);
-		},
-		[db, reachabilityFilter],
-	);
-
-	// reachabilityFilter の変更時に現在の入力で再検索する。
-	// 親が選択した相手側バス停が変わったときに即座に候補を絞り込み直すため、
-	// ドロップダウンが開いている状態でもその中身だけを更新する（Escape で
-	// 閉じた状態は維持する）。
-	useEffect(() => {
-		if (query.trim() === "") {
-			setResults([]);
+	const handleSearch = useCallback((value: string) => {
+		setQuery(value);
+		setActiveIndex(-1);
+		if (value.trim() === "") {
+			setIsOpen(false);
 			return;
 		}
-		const found = searchStops(db, query, undefined, reachabilityFilter);
-		setResults(found);
-	}, [reachabilityFilter, db, query]);
+		// results は派生値として自動再計算されるため、ここでは開閉のみ制御する。
+		setIsOpen(true);
+	}, []);
 
 	const handleSelect = useCallback(
 		(stop: StopSearchResult) => {
 			setQuery(stop.stop_name);
-			setResults([]);
 			setIsOpen(false);
 			setActiveIndex(-1);
 			onSelect(stop);

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { Database } from "sql.js";
 import { getAgencyColor } from "../lib/agency-colors";
-import { type StopSearchResult, searchStops } from "../lib/stop-search";
+import {
+	type ReachabilityFilter,
+	type StopSearchResult,
+	searchStops,
+} from "../lib/stop-search";
 
 type StopSearchProps = {
 	/** sql.js データベースインスタンス */
@@ -14,6 +18,12 @@ type StopSearchProps = {
 	selectedStop?: StopSearchResult | null;
 	/** placeholder テキスト */
 	placeholder?: string;
+	/**
+	 * Issue #90: 候補を直通便で到達可能なバス停に絞り込むフィルタ。
+	 * 乗車側では reachableToDestination、降車側では reachableFromOrigin を
+	 * 親コンポーネントで構築して渡す。
+	 */
+	reachabilityFilter?: ReachabilityFilter;
 };
 
 /** バス停名のインクリメンタルサーチコンポーネント */
@@ -23,6 +33,7 @@ export function StopSearch({
 	onSelect,
 	selectedStop = null,
 	placeholder = "バス停名を入力",
+	reachabilityFilter,
 }: StopSearchProps) {
 	const id = useId();
 	const [query, setQuery] = useState(selectedStop?.stop_name ?? "");
@@ -46,12 +57,25 @@ export function StopSearch({
 				setIsOpen(false);
 				return;
 			}
-			const found = searchStops(db, value);
+			const found = searchStops(db, value, undefined, reachabilityFilter);
 			setResults(found);
 			setIsOpen(found.length > 0);
 		},
-		[db],
+		[db, reachabilityFilter],
 	);
+
+	// reachabilityFilter の変更時に現在の入力で再検索する。
+	// 親が選択した相手側バス停が変わったときに即座に候補を絞り込み直すため、
+	// ドロップダウンが開いている状態でもその中身だけを更新する（Escape で
+	// 閉じた状態は維持する）。
+	useEffect(() => {
+		if (query.trim() === "") {
+			setResults([]);
+			return;
+		}
+		const found = searchStops(db, query, undefined, reachabilityFilter);
+		setResults(found);
+	}, [reachabilityFilter, db, query]);
 
 	const handleSelect = useCallback(
 		(stop: StopSearchResult) => {

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -58,6 +58,13 @@ export function StopSearch({
 		return searchStops(db, query, undefined, reachabilityFilter);
 	}, [db, query, reachabilityFilter]);
 
+	// listbox の実在状態。`isOpen` は「ユーザーが明示的に閉じていない」を表し、
+	// 実際に listbox を描画するか否かは候補の有無との AND で決まる。
+	// aria-expanded と描画条件をこの派生値で一元化することで、候補 0 件時に
+	// aria-expanded="true" のまま listbox が無いという WAI-ARIA 違反を防ぐ
+	// （coderabbitai #96 指摘）。
+	const isListboxOpen = isOpen && results.length > 0;
+
 	// 外部から selectedStop が変更された場合に入力欄を同期する
 	useEffect(() => {
 		setQuery(selectedStop?.stop_name ?? "");
@@ -146,14 +153,14 @@ export function StopSearch({
 				}}
 				role="combobox"
 				aria-autocomplete="list"
-				aria-expanded={isOpen}
+				aria-expanded={isListboxOpen}
 				aria-controls={`stop-search-listbox-${id}`}
 				aria-activedescendant={
 					activeIndex >= 0 ? `stop-option-${id}-${activeIndex}` : undefined
 				}
 				autoComplete="off"
 			/>
-			{isOpen && results.length > 0 && (
+			{isListboxOpen && (
 				<div
 					id={`stop-search-listbox-${id}`}
 					className="menu dropdown-content bg-base-100 rounded-box z-10 mt-1 max-h-60 w-full overflow-y-auto shadow-lg"

--- a/src/lib/stop-reachability.ts
+++ b/src/lib/stop-reachability.ts
@@ -1,0 +1,55 @@
+import type { Database } from "sql.js";
+
+/**
+ * from のいずれかから to のいずれかへ直通便で到達できるかを判定する。
+ *
+ * Issue #90: 乗り換えを前提としないため、同一 trip 上で
+ * from.stop_sequence < to.stop_sequence を満たす停留所ペアが
+ * 1 組でも存在すれば到達可能とみなす。
+ *
+ * 大規模な路線網でも EXISTS により最初のヒットで探索が止まるため、
+ * 停留所選択やフォーム送信時のリアルタイム判定に適した計算量になる。
+ *
+ * @param db sql.js データベース
+ * @param fromStopIds 乗車側の候補 stop_id 群（クラスタ展開後を想定）
+ * @param toStopIds 降車側の候補 stop_id 群（クラスタ展開後を想定）
+ * @returns いずれかの (from, to) 組で直通便があれば true
+ */
+export function isReachable(
+	db: Database,
+	fromStopIds: string[],
+	toStopIds: string[],
+): boolean {
+	// 空配列に対してはクエリを投げず false を返す。
+	// IN () は SQL 構文エラーになるため防御的にガードする。
+	if (fromStopIds.length === 0 || toStopIds.length === 0) {
+		return false;
+	}
+
+	const fromPlaceholders = fromStopIds.map(() => "?").join(", ");
+	const toPlaceholders = toStopIds.map(() => "?").join(", ");
+
+	const stmt = db.prepare(
+		`SELECT EXISTS (
+			SELECT 1
+			FROM stop_times st_from
+			JOIN stop_times st_to
+				ON st_from.trip_id = st_to.trip_id
+				AND st_from.stop_sequence < st_to.stop_sequence
+			WHERE st_from.stop_id IN (${fromPlaceholders})
+				AND st_to.stop_id IN (${toPlaceholders})
+		) AS reachable`,
+	);
+	try {
+		stmt.bind([...fromStopIds, ...toStopIds]);
+		if (!stmt.step()) {
+			// SELECT EXISTS は必ず 1 行返すので通常このパスには到達しない。
+			// 防御的に false を返す。
+			return false;
+		}
+		const row = stmt.getAsObject() as { reachable: number };
+		return row.reachable === 1;
+	} finally {
+		stmt.free();
+	}
+}

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -27,6 +27,20 @@ export type StopSearchResult = {
 /** 検索結果の最大件数 */
 const DEFAULT_LIMIT = 20;
 
+/**
+ * 到達可能性フィルタオプション。
+ *
+ * Issue #90: 乗り換えを前提としないため、検索結果から直通便で
+ * 到達不能なバス停を除外するために用いる。両フィールドを同時に
+ * 指定した場合は AND 条件で絞り込む。
+ */
+export type ReachabilityFilter = {
+	/** 指定した stop_id 群のいずれかから直通便で到達できる候補のみ返す */
+	reachableFromOrigin?: string[];
+	/** 指定した stop_id 群のいずれかに直通便で到達できる候補のみ返す */
+	reachableToDestination?: string[];
+};
+
 /** SQL から取得する生データの型 */
 type RawStopRow = {
 	stop_id: string;
@@ -54,7 +68,8 @@ type StopCluster = {
 export function searchStops(
 	db: Database,
 	query: string,
-	limit = DEFAULT_LIMIT,
+	limit: number = DEFAULT_LIMIT,
+	filter: ReachabilityFilter = {},
 ): StopSearchResult[] {
 	const trimmed = query.trim();
 	if (trimmed === "") {
@@ -64,11 +79,49 @@ export function searchStops(
 	const sanitizedLimit = Math.max(1, Math.min(Math.floor(limit), 100));
 
 	const escaped = escapeLike(trimmed);
-	const stmt = db.prepare(
-		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE stop_name LIKE ? ESCAPE '\\' ORDER BY stop_name, stop_id",
-	);
+
+	// ReachabilityFilter の EXISTS 句を組み立てる。
+	// 空配列は「フィルタなし」と解釈し、呼び出し側で未選択状態を
+	// 安全に扱えるようにする（クラスタ展開の結果が空のときの防御）。
+	const whereClauses: string[] = ["stop_name LIKE ? ESCAPE '\\'"];
+	const bindings: (string | number)[] = [`%${escaped}%`];
+
+	const originIds = filter.reachableFromOrigin;
+	if (originIds !== undefined && originIds.length > 0) {
+		const placeholders = originIds.map(() => "?").join(", ");
+		whereClauses.push(
+			`EXISTS (
+				SELECT 1 FROM stop_times st_from
+				JOIN stop_times st_to
+					ON st_from.trip_id = st_to.trip_id
+					AND st_from.stop_sequence < st_to.stop_sequence
+				WHERE st_from.stop_id IN (${placeholders})
+					AND st_to.stop_id = stops.stop_id
+			)`,
+		);
+		bindings.push(...originIds);
+	}
+
+	const destinationIds = filter.reachableToDestination;
+	if (destinationIds !== undefined && destinationIds.length > 0) {
+		const placeholders = destinationIds.map(() => "?").join(", ");
+		whereClauses.push(
+			`EXISTS (
+				SELECT 1 FROM stop_times st_from
+				JOIN stop_times st_to
+					ON st_from.trip_id = st_to.trip_id
+					AND st_from.stop_sequence < st_to.stop_sequence
+				WHERE st_from.stop_id = stops.stop_id
+					AND st_to.stop_id IN (${placeholders})
+			)`,
+		);
+		bindings.push(...destinationIds);
+	}
+
+	const sql = `SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE ${whereClauses.join(" AND ")} ORDER BY stop_name, stop_id`;
+	const stmt = db.prepare(sql);
 	try {
-		stmt.bind([`%${escaped}%`]);
+		stmt.bind(bindings);
 		const rawRows: RawStopRow[] = [];
 		while (stmt.step()) {
 			const row = stmt.getAsObject() as unknown as RawStopRow;
@@ -175,9 +228,7 @@ function clusterByNameAndDistance(rows: RawStopRow[]): StopCluster[] {
 		for (let j = i + 1; j < clusters.length; j++) {
 			const canMerge =
 				normalizedMergedNames[i].some((ni) =>
-					normalizedMergedNames[j].some((nj) =>
-						normalizedNamesContain(ni, nj),
-					),
+					normalizedMergedNames[j].some((nj) => normalizedNamesContain(ni, nj)),
 				) &&
 				distanceMeters(
 					clusters[i].lat,
@@ -320,8 +371,7 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 	const degPerMeter = 1 / 111_000; // 緯度 1 度 ≈ 111km
 	const latDelta = MERGE_THRESHOLD_METERS * degPerMeter;
 	const lonDelta =
-		MERGE_THRESHOLD_METERS /
-		(111_000 * Math.cos((refLat * Math.PI) / 180));
+		MERGE_THRESHOLD_METERS / (111_000 * Math.cos((refLat * Math.PI) / 180));
 	const nearbyStmt = db.prepare(
 		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE stop_lat BETWEEN ? AND ? AND stop_lon BETWEEN ? AND ?",
 	);
@@ -341,7 +391,10 @@ export function getSiblingStopIds(db: Database, stopId: string): string[] {
 			};
 			if (siblingIds.has(row.stop_id)) continue;
 			if (
-				normalizedNamesContain(normalizedRefName, normalizeName(row.stop_name)) &&
+				normalizedNamesContain(
+					normalizedRefName,
+					normalizeName(row.stop_name),
+				) &&
 				distanceMeters(refLat, refLon, row.stop_lat, row.stop_lon) <=
 					MERGE_THRESHOLD_METERS
 			) {

--- a/src/lib/stop-search.ts
+++ b/src/lib/stop-search.ts
@@ -1,5 +1,6 @@
 import type { Database } from "sql.js";
 import { NEARBY_THRESHOLD_METERS, distanceMeters } from "./geo-utils";
+import { isReachable } from "./stop-reachability";
 
 /** 名前統合の距離閾値（メートル） */
 const MERGE_THRESHOLD_METERS = 200;
@@ -80,85 +81,80 @@ export function searchStops(
 
 	const escaped = escapeLike(trimmed);
 
-	// ReachabilityFilter の EXISTS 句を組み立てる。
+	// coderabbitai #96 指摘: 到達可能性フィルタは SQL 段階ではなく
+	// クラスタリング後に適用する。SQL 段階で個別 stop を除外すると、
+	// クラスタ内で一部メンバーのみ直通便の起点/終点に成り得るケースで
+	// `clusterStopIds` の「クラスタに含まれる全物理バス停」という契約が
+	// 破壊される（事業者バッジの欠落や名前統合の崩れを招く）ため。
+	// ここでは名前マッチのみを SQL で行い、到達可能性はクラスタ単位で
+	// `isReachable` を使って判定する。
+	//
 	// 空配列は「フィルタなし」と解釈し、呼び出し側で未選択状態を
 	// 安全に扱えるようにする（クラスタ展開の結果が空のときの防御）。
-	const whereClauses: string[] = ["stop_name LIKE ? ESCAPE '\\'"];
-	const bindings: (string | number)[] = [`%${escaped}%`];
-
-	const originIds = filter.reachableFromOrigin;
-	if (originIds !== undefined && originIds.length > 0) {
-		const placeholders = originIds.map(() => "?").join(", ");
-		whereClauses.push(
-			`EXISTS (
-				SELECT 1 FROM stop_times st_from
-				JOIN stop_times st_to
-					ON st_from.trip_id = st_to.trip_id
-					AND st_from.stop_sequence < st_to.stop_sequence
-				WHERE st_from.stop_id IN (${placeholders})
-					AND st_to.stop_id = stops.stop_id
-			)`,
-		);
-		bindings.push(...originIds);
-	}
-
-	const destinationIds = filter.reachableToDestination;
-	if (destinationIds !== undefined && destinationIds.length > 0) {
-		const placeholders = destinationIds.map(() => "?").join(", ");
-		whereClauses.push(
-			`EXISTS (
-				SELECT 1 FROM stop_times st_from
-				JOIN stop_times st_to
-					ON st_from.trip_id = st_to.trip_id
-					AND st_from.stop_sequence < st_to.stop_sequence
-				WHERE st_from.stop_id = stops.stop_id
-					AND st_to.stop_id IN (${placeholders})
-			)`,
-		);
-		bindings.push(...destinationIds);
-	}
-
-	const sql = `SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE ${whereClauses.join(" AND ")} ORDER BY stop_name, stop_id`;
+	const sql =
+		"SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE stop_name LIKE ? ESCAPE '\\' ORDER BY stop_name, stop_id";
 	const stmt = db.prepare(sql);
+	let rawRows: RawStopRow[];
 	try {
-		stmt.bind(bindings);
-		const rawRows: RawStopRow[] = [];
+		stmt.bind([`%${escaped}%`]);
+		rawRows = [];
 		while (stmt.step()) {
 			const row = stmt.getAsObject() as unknown as RawStopRow;
 			rawRows.push(row);
 		}
-
-		if (rawRows.length === 0) {
-			return [];
-		}
-
-		const clusters = clusterByNameAndDistance(rawRows);
-		const needsDisambiguation = findNamesNeedingDisambiguation(clusters);
-		const results: StopSearchResult[] = [];
-
-		for (const cluster of clusters) {
-			if (results.length >= sanitizedLimit) break;
-
-			const result: StopSearchResult = {
-				stop_id: cluster.representativeId,
-				stop_name: cluster.stopName,
-				clusterStopIds: cluster.stopIds,
-			};
-
-			if (needsDisambiguation.has(cluster.stopName)) {
-				result.disambiguationLabel = resolveDisambiguationLabel(
-					db,
-					cluster.representativeId,
-				);
-			}
-
-			results.push(result);
-		}
-
-		return results;
 	} finally {
 		stmt.free();
 	}
+
+	if (rawRows.length === 0) {
+		return [];
+	}
+
+	const clusters = clusterByNameAndDistance(rawRows);
+
+	const originIds = filter.reachableFromOrigin;
+	const hasOriginFilter = originIds !== undefined && originIds.length > 0;
+	const destinationIds = filter.reachableToDestination;
+	const hasDestinationFilter =
+		destinationIds !== undefined && destinationIds.length > 0;
+
+	// クラスタ単位の到達可能性判定。クラスタ内のいずれかのメンバーが
+	// 条件を満たせばクラスタを採用し、clusterStopIds は生成時の完全な
+	// 集合を保持する。
+	const filteredClusters = clusters.filter((cluster) => {
+		const prefixedIds = cluster.stopIds;
+		if (hasOriginFilter && !isReachable(db, originIds, prefixedIds)) {
+			return false;
+		}
+		if (hasDestinationFilter && !isReachable(db, prefixedIds, destinationIds)) {
+			return false;
+		}
+		return true;
+	});
+
+	const needsDisambiguation = findNamesNeedingDisambiguation(filteredClusters);
+	const results: StopSearchResult[] = [];
+
+	for (const cluster of filteredClusters) {
+		if (results.length >= sanitizedLimit) break;
+
+		const result: StopSearchResult = {
+			stop_id: cluster.representativeId,
+			stop_name: cluster.stopName,
+			clusterStopIds: cluster.stopIds,
+		};
+
+		if (needsDisambiguation.has(cluster.stopName)) {
+			result.disambiguationLabel = resolveDisambiguationLabel(
+				db,
+				cluster.representativeId,
+			);
+		}
+
+		results.push(result);
+	}
+
+	return results;
 }
 
 /**

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -7,6 +7,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { type ReactElement, useState } from "react";
 import initSqlJs from "sql.js";
+import type { Database } from "sql.js";
 import {
 	afterEach,
 	beforeAll,
@@ -16,7 +17,6 @@ import {
 	it,
 	vi,
 } from "vitest";
-import type { Database } from "sql.js";
 import { RouteRegistration } from "../src/components/RouteRegistration";
 import { ToastContainer } from "../src/components/Toast";
 import type { NotifyInputCommitResult } from "../src/hooks/useNotifyBeforeMinutesInput";
@@ -59,6 +59,82 @@ const testStops: GtfsData["stops"] = [
 	},
 ];
 
+/**
+ * Issue #90: 共通テストデータの全バス停間で直通便が成立するよう、
+ * 往復の trip と stop_times を用意する。これにより乗降の順序を問わず
+ * 既存の「from → to を選んで登録」テストが到達可能性ガードを通過する。
+ */
+const testRoutes: GtfsData["routes"] = [
+	{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+];
+
+const testCalendar: GtfsData["calendar"] = [
+	{
+		service_id: "weekday",
+		monday: 1,
+		tuesday: 1,
+		wednesday: 1,
+		thursday: 1,
+		friday: 1,
+		saturday: 0,
+		sunday: 0,
+		start_date: "20260401",
+		end_date: "20280407",
+	},
+];
+
+const testTrips: GtfsData["trips"] = [
+	{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+	{ trip_id: "T002", route_id: "R001", service_id: "weekday" },
+];
+
+const testStopTimes: GtfsData["stop_times"] = [
+	// T001: 旭川駅前 → 市役所前 → 旭川四条駅
+	{
+		trip_id: "T001",
+		arrival_time: "08:00:00",
+		departure_time: "08:00:00",
+		stop_id: "S001",
+		stop_sequence: 1,
+	},
+	{
+		trip_id: "T001",
+		arrival_time: "08:05:00",
+		departure_time: "08:05:00",
+		stop_id: "S002",
+		stop_sequence: 2,
+	},
+	{
+		trip_id: "T001",
+		arrival_time: "08:10:00",
+		departure_time: "08:10:00",
+		stop_id: "S003",
+		stop_sequence: 3,
+	},
+	// T002: 逆向き（旭川四条駅 → 市役所前 → 旭川駅前）
+	{
+		trip_id: "T002",
+		arrival_time: "09:00:00",
+		departure_time: "09:00:00",
+		stop_id: "S003",
+		stop_sequence: 1,
+	},
+	{
+		trip_id: "T002",
+		arrival_time: "09:05:00",
+		departure_time: "09:05:00",
+		stop_id: "S002",
+		stop_sequence: 2,
+	},
+	{
+		trip_id: "T002",
+		arrival_time: "09:10:00",
+		departure_time: "09:10:00",
+		stop_id: "S001",
+		stop_sequence: 3,
+	},
+];
+
 const emptyGtfsBase: GtfsData = {
 	agency: [{ agency_id: "A001", agency_name: "テストバス" }],
 	stops: [],
@@ -82,7 +158,18 @@ beforeAll(async () => {
 beforeEach(() => {
 	db = new SQL.Database();
 	createSchema(db);
-	loadGtfsData(db, { ...emptyGtfsBase, stops: testStops }, "test");
+	loadGtfsData(
+		db,
+		{
+			...emptyGtfsBase,
+			stops: testStops,
+			routes: testRoutes,
+			calendar: testCalendar,
+			trips: testTrips,
+			stop_times: testStopTimes,
+		},
+		"test",
+	);
 });
 
 afterEach(() => {
@@ -121,7 +208,9 @@ function renderComponent(routes: RegisteredRouteEntry[] = []) {
 function NotifyHarness(props: {
 	db: Database;
 	routes: RegisteredRouteEntry[];
-	onAdd: (entry: Omit<import("../src/types/route-entry").RouteEntry, "id">) => Promise<number>;
+	onAdd: (
+		entry: Omit<import("../src/types/route-entry").RouteEntry, "id">,
+	) => Promise<number>;
 	onUpdate: (entry: RegisteredRouteEntry) => Promise<void>;
 	onDelete: (id: number) => Promise<void>;
 	onRequestNotificationPermission?: () => Promise<NotificationPermission>;
@@ -131,11 +220,7 @@ function NotifyHarness(props: {
 	/** commit 時に minutes 引数で呼ばれる。throw すると rollback される */
 	onCommitSpy?: (minutes: number) => void;
 }) {
-	const {
-		initialMinutes = 5,
-		onCommitSpy,
-		...componentProps
-	} = props;
+	const { initialMinutes = 5, onCommitSpy, ...componentProps } = props;
 	const [minutes, setMinutes] = useState(initialMinutes);
 	const [inputValue, setInputValue] = useState(String(initialMinutes));
 
@@ -309,18 +394,20 @@ describe("RouteRegistration コンポーネント", () => {
 	});
 
 	it("同一バス停を選択して登録するとエラーメッセージが表示される", async () => {
-		renderComponent();
+		// Issue #90: 降車ドロップダウンは乗車と同じバス停を除外するため、
+		// 通常フローでは同一バス停を選択できない。編集経路で同一バス停の
+		// エントリを読み込み、フォーム上で同じバス停同士になった状態を
+		// 再現して submit ガードを検証する。
+		const sameFromToRoute: RegisteredRouteEntry = {
+			id: 1,
+			fromStopId: "test:S001",
+			toStopId: "test:S001",
+			walkMinutes: 5,
+		};
+		renderComponent([sameFromToRoute]);
 
-		const comboboxes = screen.getAllByRole("combobox");
-		await userEvent.type(comboboxes[0], "旭川駅");
-		await userEvent.click(screen.getByText("旭川駅前"));
-		await userEvent.type(comboboxes[1], "旭川駅");
-		await userEvent.click(screen.getByText("旭川駅前"));
-
-		const walkInput = screen.getByLabelText("徒歩所要時間（分）");
-		await userEvent.type(walkInput, "5");
-
-		await userEvent.click(screen.getByRole("button", { name: "登録" }));
+		await userEvent.click(screen.getByRole("button", { name: "編集" }));
+		await userEvent.click(screen.getByRole("button", { name: "更新" }));
 
 		expect(
 			screen.getByText(
@@ -1636,5 +1723,190 @@ describe("RouteRegistration コンポーネント", () => {
 		const rows = screen.getAllByRole("row");
 		// ヘッダ行 + データ行 2 件
 		expect(rows).toHaveLength(3);
+	});
+});
+
+/**
+ * Issue #90: 乗降車バス停の候補を直通便で絞り込む統合テスト。
+ *
+ * 専用の GTFS データを構築し、T001: A→B→C の直通便のみが存在する状況で、
+ * - 乗車バス停選択後の降車バス停候補が絞り込まれること
+ * - 直通便が無い組み合わせで submit してもガードが働くこと
+ * を確認する。
+ */
+describe("RouteRegistration（到達可能性フィルタ）", () => {
+	const stops: GtfsData["stops"] = [
+		{ stop_id: "S001", stop_name: "A停", stop_lat: 43.76, stop_lon: 142.35 },
+		{ stop_id: "S002", stop_name: "B停", stop_lat: 43.77, stop_lon: 142.36 },
+		{ stop_id: "S003", stop_name: "C停", stop_lat: 43.78, stop_lon: 142.37 },
+		{ stop_id: "S004", stop_name: "D停", stop_lat: 43.79, stop_lon: 142.38 },
+	];
+
+	const routes: GtfsData["routes"] = [
+		{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+	];
+
+	const calendar: GtfsData["calendar"] = [
+		{
+			service_id: "weekday",
+			monday: 1,
+			tuesday: 1,
+			wednesday: 1,
+			thursday: 1,
+			friday: 1,
+			saturday: 0,
+			sunday: 0,
+			start_date: "20260401",
+			end_date: "20280407",
+		},
+	];
+
+	const trips: GtfsData["trips"] = [
+		{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+	];
+
+	// T001: A → B → C の直通便のみ。D は孤立。
+	const stopTimes: GtfsData["stop_times"] = [
+		{
+			trip_id: "T001",
+			arrival_time: "08:00:00",
+			departure_time: "08:00:00",
+			stop_id: "S001",
+			stop_sequence: 1,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:05:00",
+			departure_time: "08:05:00",
+			stop_id: "S002",
+			stop_sequence: 2,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:10:00",
+			departure_time: "08:10:00",
+			stop_id: "S003",
+			stop_sequence: 3,
+		},
+	];
+
+	beforeEach(() => {
+		db = new SQL.Database();
+		createSchema(db);
+		loadGtfsData(
+			db,
+			{
+				...emptyGtfsBase,
+				stops,
+				routes,
+				calendar,
+				trips,
+				stop_times: stopTimes,
+			},
+			"test",
+		);
+	});
+
+	it("乗車バス停選択後、降車バス停の候補は直通便で到達可能な停留所のみ表示される", async () => {
+		const onAdd = vi.fn().mockResolvedValue(1);
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={[]}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// 乗車バス停で A を選択
+		const fromInput = screen.getByRole("combobox", { name: "乗車バス停" });
+		await userEvent.type(fromInput, "A停");
+		await userEvent.click(screen.getByText("A停"));
+
+		// 降車バス停のドロップダウンを開く
+		const toInput = screen.getByRole("combobox", { name: "降車バス停" });
+		await userEvent.type(toInput, "停");
+
+		// A 発の直通便で到達できる B, C のみが候補になり、D と A 自身は除外される
+		expect(screen.getByText("B停")).toBeInTheDocument();
+		expect(screen.getByText("C停")).toBeInTheDocument();
+		// A は乗車バス停の入力欄に残っているため、getAllByText で降車ドロップダウン側に
+		// A が現れていないことを確認する（listbox 内に A が無いことを検証）
+		const listbox = screen.getByRole("listbox");
+		expect(listbox).not.toHaveTextContent("A停");
+		expect(listbox).not.toHaveTextContent("D停");
+	});
+
+	it("降車バス停選択後、乗車バス停の候補は直通便で到達可能な停留所のみ表示される", async () => {
+		const onAdd = vi.fn().mockResolvedValue(1);
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={[]}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// 降車バス停で C を選択
+		const toInput = screen.getByRole("combobox", { name: "降車バス停" });
+		await userEvent.type(toInput, "C停");
+		await userEvent.click(screen.getByText("C停"));
+
+		// 乗車バス停のドロップダウンを開く
+		const fromInput = screen.getByRole("combobox", { name: "乗車バス停" });
+		await userEvent.type(fromInput, "停");
+
+		// C に直通で到達できる A, B のみが候補になる
+		expect(screen.getByText("A停")).toBeInTheDocument();
+		expect(screen.getByText("B停")).toBeInTheDocument();
+		const listbox = screen.getByRole("listbox");
+		expect(listbox).not.toHaveTextContent("C停");
+		expect(listbox).not.toHaveTextContent("D停");
+	});
+
+	it("直通便の無い組み合わせで submit するとエラーメッセージが表示され onAdd は呼ばれない", async () => {
+		const onAdd = vi.fn().mockResolvedValue(1);
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		// 編集経由で A → D（直通便なし）を事前に入れる。
+		// 編集モードで form state にセットされたあと、そのまま「更新」を押して
+		// submit ガードが働くかを検証する。
+		const unreachableRoute: RegisteredRouteEntry = {
+			id: 1,
+			fromStopId: "test:S001",
+			toStopId: "test:S004",
+			walkMinutes: 10,
+		};
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={[unreachableRoute]}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// 編集ボタンを押して form に A → D を載せる
+		await userEvent.click(screen.getByRole("button", { name: "編集" }));
+
+		// 「更新」ボタンを押す → submit ガードでエラーが表示される
+		await userEvent.click(screen.getByRole("button", { name: "更新" }));
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			/直通便|到達|経路がありません/,
+		);
+		expect(onUpdate).not.toHaveBeenCalled();
 	});
 });

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1820,6 +1820,9 @@ describe("RouteRegistration（到達可能性フィルタ）", () => {
 	];
 
 	beforeEach(() => {
+		// 外側 beforeEach で生成された db を上書きする前に明示的に解放する
+		// （sql.js の WASM インスタンスはリーク防止のため close が必要）
+		db.close();
 		db = new SQL.Database();
 		createSchema(db);
 		loadGtfsData(

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1936,8 +1936,11 @@ describe("RouteRegistration（到達可能性フィルタ）", () => {
 		// 「更新」ボタンを押す → submit ガードでエラーが表示される
 		await userEvent.click(screen.getByRole("button", { name: "更新" }));
 
+		// UX 文言の意図しない退化を検出できるよう、実装側の実文言
+		// 「選択したバス停間に直通便がありません。別の組み合わせを選んでください」の
+		// 冒頭フレーズにマッチさせる（coderabbitai #96 nitpick）。
 		expect(screen.getByRole("alert")).toHaveTextContent(
-			/直通便|到達|経路がありません/,
+			/選択したバス停間に直通便がありません/,
 		);
 		expect(onUpdate).not.toHaveBeenCalled();
 	});

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -295,6 +295,9 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 	];
 
 	beforeEach(() => {
+		// 外側 beforeEach で生成された db を上書きする前に明示的に解放する
+		// （sql.js の WASM インスタンスはリーク防止のため close が必要）
+		db.close();
 		db = new SQL.Database();
 		createSchema(db);
 		loadGtfsData(

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -235,3 +235,155 @@ describe("StopSearch コンポーネント", () => {
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 	});
 });
+
+describe("StopSearch（到達可能性フィルタ）", () => {
+	// Issue #90: 乗降車バス停の組み合わせで直通便が無いものを
+	// ドロップダウンから除外するために reachabilityFilter props を受け取る。
+	const stops: GtfsData["stops"] = [
+		{ stop_id: "S001", stop_name: "A停", stop_lat: 43.76, stop_lon: 142.35 },
+		{ stop_id: "S002", stop_name: "B停", stop_lat: 43.77, stop_lon: 142.36 },
+		{ stop_id: "S003", stop_name: "C停", stop_lat: 43.78, stop_lon: 142.37 },
+		{ stop_id: "S004", stop_name: "D停", stop_lat: 43.79, stop_lon: 142.38 },
+	];
+
+	const routes: GtfsData["routes"] = [
+		{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+	];
+
+	const calendar: GtfsData["calendar"] = [
+		{
+			service_id: "weekday",
+			monday: 1,
+			tuesday: 1,
+			wednesday: 1,
+			thursday: 1,
+			friday: 1,
+			saturday: 0,
+			sunday: 0,
+			start_date: "20260401",
+			end_date: "20280407",
+		},
+	];
+
+	const trips: GtfsData["trips"] = [
+		{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+	];
+
+	// T001: A → B → C の直通便のみ。D は孤立。
+	const stopTimes: GtfsData["stop_times"] = [
+		{
+			trip_id: "T001",
+			arrival_time: "08:00:00",
+			departure_time: "08:00:00",
+			stop_id: "S001",
+			stop_sequence: 1,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:05:00",
+			departure_time: "08:05:00",
+			stop_id: "S002",
+			stop_sequence: 2,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:10:00",
+			departure_time: "08:10:00",
+			stop_id: "S003",
+			stop_sequence: 3,
+		},
+	];
+
+	beforeEach(() => {
+		db = new SQL.Database();
+		createSchema(db);
+		loadGtfsData(
+			db,
+			{
+				...emptyGtfsBase,
+				stops,
+				routes,
+				calendar,
+				trips,
+				stop_times: stopTimes,
+			},
+			"test",
+		);
+	});
+
+	it("reachabilityFilter 未指定時は全候補を表示する", async () => {
+		const onSelect = vi.fn();
+		render(<StopSearch db={db} label="降車バス停" onSelect={onSelect} />);
+
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "停");
+		expect(screen.getByText("A停")).toBeInTheDocument();
+		expect(screen.getByText("B停")).toBeInTheDocument();
+		expect(screen.getByText("C停")).toBeInTheDocument();
+		expect(screen.getByText("D停")).toBeInTheDocument();
+	});
+
+	it("reachableFromOrigin 指定時は origin から直通で到達可能な候補のみ表示する", async () => {
+		const onSelect = vi.fn();
+		render(
+			<StopSearch
+				db={db}
+				label="降車バス停"
+				onSelect={onSelect}
+				reachabilityFilter={{ reachableFromOrigin: ["test:S001"] }}
+			/>,
+		);
+
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "停");
+		// A→B→C の直通便があるため B, C はヒット、孤立した D と origin の A は除外
+		expect(screen.getByText("B停")).toBeInTheDocument();
+		expect(screen.getByText("C停")).toBeInTheDocument();
+		expect(screen.queryByText("A停")).not.toBeInTheDocument();
+		expect(screen.queryByText("D停")).not.toBeInTheDocument();
+	});
+
+	it("reachableToDestination 指定時は destination に直通で到達できる候補のみ表示する", async () => {
+		const onSelect = vi.fn();
+		render(
+			<StopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				reachabilityFilter={{ reachableToDestination: ["test:S003"] }}
+			/>,
+		);
+
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "停");
+		// C に直通で到達できるのは A, B のみ
+		expect(screen.getByText("A停")).toBeInTheDocument();
+		expect(screen.getByText("B停")).toBeInTheDocument();
+		expect(screen.queryByText("C停")).not.toBeInTheDocument();
+		expect(screen.queryByText("D停")).not.toBeInTheDocument();
+	});
+
+	it("reachabilityFilter の変更時にドロップダウン表示が追従する", async () => {
+		const onSelect = vi.fn();
+		const { rerender } = render(
+			<StopSearch db={db} label="降車バス停" onSelect={onSelect} />,
+		);
+
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "停");
+		expect(screen.getByText("D停")).toBeInTheDocument();
+
+		// フィルタを追加して再描画 → D は除外されるべき
+		rerender(
+			<StopSearch
+				db={db}
+				label="降車バス停"
+				onSelect={onSelect}
+				reachabilityFilter={{ reachableFromOrigin: ["test:S001"] }}
+			/>,
+		);
+		// 既に開いているドロップダウンがフィルタ変更に応じて更新される
+		expect(screen.queryByText("D停")).not.toBeInTheDocument();
+		expect(screen.getByText("B停")).toBeInTheDocument();
+	});
+});

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -218,6 +218,22 @@ describe("StopSearch コンポーネント", () => {
 		expect(input).toHaveAttribute("aria-expanded", "true");
 	});
 
+	it("候補が 0 件のクエリでは aria-expanded が false のままになる", async () => {
+		// CodeRabbit 指摘: listbox が描画されないのに aria-expanded="true" は
+		// WAI-ARIA combobox パターンに違反する。描画条件と aria-expanded は
+		// 「候補が 1 件以上かつユーザーが閉じていない」の派生値で一元化する。
+		const onSelect = vi.fn();
+		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "該当しない文字列xyz");
+
+		// listbox が描画されていない
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+		// aria-expanded は実在する listbox の状態を反映する必要がある
+		expect(input).toHaveAttribute("aria-expanded", "false");
+	});
+
 	it("ドロップダウン外クリックで閉じる", async () => {
 		const onSelect = vi.fn();
 		render(

--- a/test/stop-reachability.test.ts
+++ b/test/stop-reachability.test.ts
@@ -1,0 +1,315 @@
+import initSqlJs from "sql.js";
+import type { Database } from "sql.js";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
+import { isReachable } from "../src/lib/stop-reachability";
+import type { GtfsData } from "../src/types/gtfs";
+
+/**
+ * 到達可能性判定のテスト。
+ *
+ * Issue #90: 乗り換えを前提としないため、直通便が 1 本以上ある場合のみ
+ * 到達可能とみなす。from から to への順序（stop_sequence）を満たす
+ * 単一 trip が存在すれば true、それ以外は false。
+ */
+
+const emptyGtfsBase: GtfsData = {
+	agency: [{ agency_id: "A001", agency_name: "テストバス" }],
+	stops: [],
+	routes: [],
+	trips: [],
+	stop_times: [],
+	calendar: [],
+	calendar_dates: [],
+	shapes: [],
+	fare_attributes: [],
+	fare_rules: [],
+};
+
+const baseStops: GtfsData["stops"] = [
+	{ stop_id: "S001", stop_name: "A", stop_lat: 43.76, stop_lon: 142.35 },
+	{ stop_id: "S002", stop_name: "B", stop_lat: 43.77, stop_lon: 142.36 },
+	{ stop_id: "S003", stop_name: "C", stop_lat: 43.78, stop_lon: 142.37 },
+	{ stop_id: "S004", stop_name: "D", stop_lat: 43.79, stop_lon: 142.38 },
+];
+
+const baseRoutes: GtfsData["routes"] = [
+	{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+];
+
+const baseCalendar: GtfsData["calendar"] = [
+	{
+		service_id: "weekday",
+		monday: 1,
+		tuesday: 1,
+		wednesday: 1,
+		thursday: 1,
+		friday: 1,
+		saturday: 0,
+		sunday: 0,
+		start_date: "20260401",
+		end_date: "20280407",
+	},
+];
+
+let SQL: Awaited<ReturnType<typeof initSqlJs>>;
+let db: Database;
+
+beforeAll(async () => {
+	SQL = await initSqlJs();
+});
+
+afterEach(() => {
+	db.close();
+});
+
+function createDb(overrides: Partial<GtfsData>) {
+	db = new SQL.Database();
+	createSchema(db);
+	loadGtfsData(
+		db,
+		{
+			...emptyGtfsBase,
+			stops: baseStops,
+			routes: baseRoutes,
+			calendar: baseCalendar,
+			...overrides,
+		},
+		"test",
+	);
+}
+
+describe("isReachable", () => {
+	it("A → B の直通便が存在するとき true", () => {
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S001"], ["test:S002"])).toBe(true);
+	});
+
+	it("逆方向（B → A のみの便）では from=A, to=B で false", () => {
+		// T001 は S002 → S001 の片方向のみ。A → B の直通便は存在しない。
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S002",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S001",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S001"], ["test:S002"])).toBe(false);
+	});
+
+	it("同一便に from と to を含み順序が正しければ true（中間停留所あり）", () => {
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:05:00",
+					departure_time: "08:05:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:10:00",
+					departure_time: "08:10:00",
+					stop_id: "S003",
+					stop_sequence: 3,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S001"], ["test:S003"])).toBe(true);
+	});
+
+	it("from と to が別々の便にしか存在しない場合は false（乗り換えは対象外）", () => {
+		// T001 は A→B、T002 は C→D。A→D の直通便は存在しない。
+		createDb({
+			trips: [
+				{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+				{ trip_id: "T002", route_id: "R001", service_id: "weekday" },
+			],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+				{
+					trip_id: "T002",
+					arrival_time: "09:00:00",
+					departure_time: "09:00:00",
+					stop_id: "S003",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T002",
+					arrival_time: "09:15:00",
+					departure_time: "09:15:00",
+					stop_id: "S004",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S001"], ["test:S004"])).toBe(false);
+	});
+
+	it("fromStopIds が空配列なら false", () => {
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, [], ["test:S002"])).toBe(false);
+	});
+
+	it("toStopIds が空配列なら false", () => {
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S001"], [])).toBe(false);
+	});
+
+	it("存在しない stop_id に対しては false", () => {
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S002",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(isReachable(db, ["test:S999"], ["test:S998"])).toBe(false);
+	});
+
+	it("複数候補のうち 1 組でも直通便があれば true（クラスタ展開ケース）", () => {
+		// T001: S001 → S003 のみ。fromIds に S001 と S002 を並べ、
+		// S001 側で直通便にヒットすることを期待する。
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+				{
+					trip_id: "T001",
+					arrival_time: "08:15:00",
+					departure_time: "08:15:00",
+					stop_id: "S003",
+					stop_sequence: 2,
+				},
+			],
+		});
+		expect(
+			isReachable(db, ["test:S002", "test:S001"], ["test:S003", "test:S004"]),
+		).toBe(true);
+	});
+
+	it("同一便で from と to が同じ stop_sequence（自己参照）では false", () => {
+		// 理論上は PRIMARY KEY 違反だが、防御的に片方向のみ検出する SQL の
+		// 挙動を検証する。stop_sequence が同じなら from < to にならない。
+		createDb({
+			trips: [{ trip_id: "T001", route_id: "R001", service_id: "weekday" }],
+			stop_times: [
+				{
+					trip_id: "T001",
+					arrival_time: "08:00:00",
+					departure_time: "08:00:00",
+					stop_id: "S001",
+					stop_sequence: 1,
+				},
+			],
+		});
+		// from と to に同じバス停を指定 → 同じ行同士では from_seq < to_seq を満たさない
+		expect(isReachable(db, ["test:S001"], ["test:S001"])).toBe(false);
+	});
+});

--- a/test/stop-search.test.ts
+++ b/test/stop-search.test.ts
@@ -1,4 +1,5 @@
 import initSqlJs from "sql.js";
+import type { Database } from "sql.js";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
 import {
@@ -418,5 +419,193 @@ describe("getStopName", () => {
 	it("存在しない stop_id の場合は stop_id をそのまま返す", () => {
 		const name = getStopName(db, "test:S999");
 		expect(name).toBe("test:S999");
+	});
+});
+
+describe("searchStops（到達可能性フィルタ）", () => {
+	// Issue #90: 乗降車バス停の候補を直通便で到達可能なものに絞り込む。
+	// テスト用に A→B→C と D→E の 2 系統を用意し、クラスタ展開込みで
+	// EXISTS サブクエリの挙動を検証する。
+	const stops: GtfsData["stops"] = [
+		{ stop_id: "S001", stop_name: "A停", stop_lat: 43.76, stop_lon: 142.35 },
+		{ stop_id: "S002", stop_name: "B停", stop_lat: 43.77, stop_lon: 142.36 },
+		{ stop_id: "S003", stop_name: "C停", stop_lat: 43.78, stop_lon: 142.37 },
+		{ stop_id: "S004", stop_name: "D停", stop_lat: 43.79, stop_lon: 142.38 },
+		{ stop_id: "S005", stop_name: "E停", stop_lat: 43.8, stop_lon: 142.39 },
+	];
+
+	const routes: GtfsData["routes"] = [
+		{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+	];
+
+	const calendar: GtfsData["calendar"] = [
+		{
+			service_id: "weekday",
+			monday: 1,
+			tuesday: 1,
+			wednesday: 1,
+			thursday: 1,
+			friday: 1,
+			saturday: 0,
+			sunday: 0,
+			start_date: "20260401",
+			end_date: "20280407",
+		},
+	];
+
+	const trips: GtfsData["trips"] = [
+		{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+		{ trip_id: "T002", route_id: "R001", service_id: "weekday" },
+	];
+
+	const stopTimes: GtfsData["stop_times"] = [
+		// T001: A → B → C の直通便
+		{
+			trip_id: "T001",
+			arrival_time: "08:00:00",
+			departure_time: "08:00:00",
+			stop_id: "S001",
+			stop_sequence: 1,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:05:00",
+			departure_time: "08:05:00",
+			stop_id: "S002",
+			stop_sequence: 2,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:10:00",
+			departure_time: "08:10:00",
+			stop_id: "S003",
+			stop_sequence: 3,
+		},
+		// T002: D → E の別系統
+		{
+			trip_id: "T002",
+			arrival_time: "09:00:00",
+			departure_time: "09:00:00",
+			stop_id: "S004",
+			stop_sequence: 1,
+		},
+		{
+			trip_id: "T002",
+			arrival_time: "09:10:00",
+			departure_time: "09:10:00",
+			stop_id: "S005",
+			stop_sequence: 2,
+		},
+	];
+
+	let db: Database;
+
+	beforeEach(() => {
+		db = new SQL.Database();
+		createSchema(db);
+		loadGtfsData(
+			db,
+			{
+				...emptyGtfsBase,
+				stops,
+				routes,
+				calendar,
+				trips,
+				stop_times: stopTimes,
+			},
+			"test",
+		);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("フィルタ未指定時は従来どおり全件返す", () => {
+		const results = searchStops(db, "停");
+		expect(results.map((r) => r.stop_name).sort()).toEqual([
+			"A停",
+			"B停",
+			"C停",
+			"D停",
+			"E停",
+		]);
+	});
+
+	it("reachableFromOrigin 指定時は origin から直通で到達可能な候補のみ返す", () => {
+		// A を origin に指定すると、A 発の直通便で行ける B と C のみが候補になる。
+		// D と E は別系統のため除外される。
+		const results = searchStops(db, "停", undefined, {
+			reachableFromOrigin: ["test:S001"],
+		});
+		expect(results.map((r) => r.stop_name).sort()).toEqual(["B停", "C停"]);
+	});
+
+	it("reachableToDestination 指定時は destination に直通で到達できる候補のみ返す", () => {
+		// C を destination に指定すると、C に直通で到達できる A と B のみが候補になる。
+		const results = searchStops(db, "停", undefined, {
+			reachableToDestination: ["test:S003"],
+		});
+		expect(results.map((r) => r.stop_name).sort()).toEqual(["A停", "B停"]);
+	});
+
+	it("reachableFromOrigin に対し origin 自身は除外される（自己ループ判定）", () => {
+		// A を origin に指定したとき、A 自身は到達先になり得ない。
+		const results = searchStops(db, "停", undefined, {
+			reachableFromOrigin: ["test:S001"],
+		});
+		expect(results.map((r) => r.stop_name)).not.toContain("A停");
+	});
+
+	it("reachableToDestination に対し destination 自身は除外される", () => {
+		const results = searchStops(db, "停", undefined, {
+			reachableToDestination: ["test:S003"],
+		});
+		expect(results.map((r) => r.stop_name)).not.toContain("C停");
+	});
+
+	it("reachableFromOrigin が空配列のときはフィルタ無指定と同じ挙動になる", () => {
+		// 空配列を「フィルタ条件なし」と解釈する。呼び出し側で clusterStopIds が
+		// 空になるケース（バス停未選択 / クラスタ展開結果が空）を防御的に扱う。
+		const results = searchStops(db, "停", undefined, {
+			reachableFromOrigin: [],
+		});
+		expect(results.map((r) => r.stop_name).sort()).toEqual([
+			"A停",
+			"B停",
+			"C停",
+			"D停",
+			"E停",
+		]);
+	});
+
+	it("reachableToDestination が空配列のときはフィルタ無指定と同じ挙動になる", () => {
+		const results = searchStops(db, "停", undefined, {
+			reachableToDestination: [],
+		});
+		expect(results.map((r) => r.stop_name).sort()).toEqual([
+			"A停",
+			"B停",
+			"C停",
+			"D停",
+			"E停",
+		]);
+	});
+
+	it("両方のフィルタを同時指定すると AND で絞り込まれる", () => {
+		// origin=A AND destination=C を満たすのは B のみ
+		// （A→B→C の中間点として両条件を満たす）
+		const results = searchStops(db, "停", undefined, {
+			reachableFromOrigin: ["test:S001"],
+			reachableToDestination: ["test:S003"],
+		});
+		expect(results.map((r) => r.stop_name)).toEqual(["B停"]);
+	});
+
+	it("limit はフィルタ後の件数に対して適用される", () => {
+		const results = searchStops(db, "停", 1, {
+			reachableFromOrigin: ["test:S001"],
+		});
+		expect(results).toHaveLength(1);
 	});
 });

--- a/test/stop-search.test.ts
+++ b/test/stop-search.test.ts
@@ -609,3 +609,125 @@ describe("searchStops（到達可能性フィルタ）", () => {
 		expect(results).toHaveLength(1);
 	});
 });
+
+describe("searchStops（クラスタ契約 × 到達可能性フィルタ）", () => {
+	// coderabbitai #96 指摘: 到達可能性フィルタは SQL の WHERE 段階ではなく
+	// クラスタリング後に適用する必要がある。SQL 段階で個別 stop を除外すると
+	// 「クラスタ内の一部のみ直通便で到達可能」なケースで clusterStopIds が
+	// 欠落し、StopSearchResult.clusterStopIds の「クラスタに含まれる全物理
+	// バス停」という契約が破壊されるため。
+	//
+	// このテストは契約そのものを検証する Red テスト。現行実装では failing する。
+	const stops: GtfsData["stops"] = [
+		// origin（クエリには含まれないため結果には出ない）
+		{
+			stop_id: "S000",
+			stop_name: "起点",
+			stop_lat: 43.76,
+			stop_lon: 142.35,
+		},
+		// クラスタ「合流停」: 同名かつ 500m 以内 → 1 クラスタに統合される
+		{
+			stop_id: "S001",
+			stop_name: "合流停",
+			stop_lat: 43.77,
+			stop_lon: 142.36,
+		},
+		{
+			stop_id: "S002",
+			stop_name: "合流停",
+			stop_lat: 43.7701,
+			stop_lon: 142.3601,
+		},
+	];
+
+	const routes: GtfsData["routes"] = [
+		{ route_id: "R001", agency_id: "A001", route_short_name: "1" },
+	];
+
+	const calendar: GtfsData["calendar"] = [
+		{
+			service_id: "weekday",
+			monday: 1,
+			tuesday: 1,
+			wednesday: 1,
+			thursday: 1,
+			friday: 1,
+			saturday: 0,
+			sunday: 0,
+			start_date: "20260401",
+			end_date: "20280407",
+		},
+	];
+
+	const trips: GtfsData["trips"] = [
+		{ trip_id: "T001", route_id: "R001", service_id: "weekday" },
+	];
+
+	// T001: S000 → S001 のみ。同じクラスタの S002 には直通便が無い。
+	const stopTimes: GtfsData["stop_times"] = [
+		{
+			trip_id: "T001",
+			arrival_time: "08:00:00",
+			departure_time: "08:00:00",
+			stop_id: "S000",
+			stop_sequence: 1,
+		},
+		{
+			trip_id: "T001",
+			arrival_time: "08:10:00",
+			departure_time: "08:10:00",
+			stop_id: "S001",
+			stop_sequence: 2,
+		},
+	];
+
+	let db: Database;
+
+	beforeEach(() => {
+		db = new SQL.Database();
+		createSchema(db);
+		loadGtfsData(
+			db,
+			{
+				...emptyGtfsBase,
+				stops,
+				routes,
+				calendar,
+				trips,
+				stop_times: stopTimes,
+			},
+			"test",
+		);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("クラスタ内の一部のみ直通便で到達可能でも clusterStopIds にはクラスタ全体が含まれる", () => {
+		// origin=S000 から直通便で到達可能なのは S001 のみ。S002 は同一クラスタ
+		// だが直通便が無い。クラスタ自体は「到達可能なメンバーが 1 つでもあれば」
+		// 結果に含め、clusterStopIds には S001 と S002 の両方を保持する。
+		const results = searchStops(db, "合流停", undefined, {
+			reachableFromOrigin: ["test:S000"],
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0].stop_name).toBe("合流停");
+		expect([...results[0].clusterStopIds].sort()).toEqual([
+			"test:S001",
+			"test:S002",
+		]);
+	});
+
+	it("クラスタ内のどのメンバーからも direct に到達できない場合のみクラスタを除外する", () => {
+		// destination=S000 に対して、クラスタ {S001, S002} のどちらからも
+		// S000 への直通便は無い（T001 は S000→S001 の一方向のみ）。
+		// この場合はクラスタごと結果から除外される。
+		const results = searchStops(db, "合流停", undefined, {
+			reachableToDestination: ["test:S000"],
+		});
+		expect(results).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

Issue #90 の対応。乗り換えを前提としないこのアプリで、直通便が存在しない乗降車バス停の組み合わせをユーザーが選んでしまう問題を解消する。

- **動的絞り込み**: 片方のバス停が選択されると、もう一方のインクリメンタルサーチの候補が「直通便で到達可能なバス停のみ」に自動で絞られる
- **submit ガード**: フォーム送信時にも `isReachable` で念のため検証し、編集経路で不整合なデータが残っていた場合にもエラーメッセージで弾く

## 実装のポイント

- `isReachable` は `stop_times` の自己結合 + `EXISTS` サブクエリで最初の直通便ヒットで探索を止める。大規模 GTFS でもリアルタイム判定可能な計算量
- `searchStops` は `ReachabilityFilter` オプションを新規に受け取り、`EXISTS` 句を `WHERE` に AND 連結。空配列は「フィルタなし」と解釈する防御的挙動
- `RouteRegistration` は `getSiblingStopIds` で上下線・事業者違いの兄弟バス停まで展開してフィルタ構築するため、同一物理停留所の直通便を取りこぼさない

## 変更ファイル

- 新規: `src/lib/stop-reachability.ts`, `test/stop-reachability.test.ts`
- 修正: `src/lib/stop-search.ts`, `src/components/StopSearch.tsx`, `src/components/RouteRegistration.tsx`
- 修正: `test/stop-search.test.ts`, `test/StopSearch.test.tsx`, `test/RouteRegistration.test.tsx`

## Test plan

- [x] `npx vitest run` で全 1033 テスト pass
- [x] `npm run build` で tsc + vite ビルド pass
- [x] `npx biome check`（変更ファイル）で lint クリーン
- [ ] ブラウザで乗車バス停を選んだあと、降車バス停のドロップダウンが直通便で到達可能なバス停のみに絞られることを確認
- [ ] 逆順（降車 → 乗車）でも同じく絞り込みが効くことを確認
- [ ] 既存登録で不整合な組み合わせ（GTFS 更新後など）を編集して submit するとエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ルート登録で出発／到着の「到達可能性」検証が入り、選択肢が相互に絞り込まれるようになりました。
  * 未到達組合せでの登録時に明確なエラーメッセージが表示され、登録をブロックします。

* **バグ修正 / アクセシビリティ**
  * 検索ドロップダウンの表示挙動とARIA属性を改善し、候補がない場合はリストを表示しません。

* **テスト**
  * 到達可能性と検索挙動を網羅する包括的なテスト群を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->