### PR TITLE
fix(test): align notify toast regex with 出発の UI wording

### DIFF
--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -1132,7 +1132,7 @@ describe("RouteRegistration コンポーネント", () => {
 			);
 			expect(
 				await screen.findByText(
-					/発車の\s*15\s*分前に通知するように設定しました/,
+					/出発の\s*15\s*分前に通知するように設定しました/,
 				),
 			).toBeInTheDocument();
 		});
@@ -1156,7 +1156,7 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(onCommitSpy).toHaveBeenCalledWith(20);
 			expect(
 				await screen.findByText(
-					/発車の\s*20\s*分前に通知するように設定しました/,
+					/出発の\s*20\s*分前に通知するように設定しました/,
 				),
 			).toBeInTheDocument();
 		});
@@ -1314,7 +1314,7 @@ describe("RouteRegistration コンポーネント", () => {
 				screen.queryByText(/通知タイミングを設定できませんでした/),
 			).not.toBeInTheDocument();
 			expect(
-				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+				screen.queryByText(/出発の.*分前に通知するように設定しました/),
 			).not.toBeInTheDocument();
 			// 親フックの commit 自体が呼ばれないことも明示的に検証する
 			expect(onCommitSpy).not.toHaveBeenCalled();
@@ -1436,7 +1436,7 @@ describe("RouteRegistration コンポーネント", () => {
 			expect(onCommitSpy).not.toHaveBeenCalled();
 			// トーストも出ない
 			expect(
-				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+				screen.queryByText(/出発の.*分前に通知するように設定しました/),
 			).not.toBeInTheDocument();
 
 			resolveDelete();
@@ -1475,7 +1475,7 @@ describe("RouteRegistration コンポーネント", () => {
 			fireEvent.keyDown(input, { key: "Enter" });
 			expect(onCommitSpy).not.toHaveBeenCalled();
 			expect(
-				screen.queryByText(/発車の.*分前に通知するように設定しました/),
+				screen.queryByText(/出発の.*分前に通知するように設定しました/),
 			).not.toBeInTheDocument();
 
 			resolveUpdate();


### PR DESCRIPTION
## Summary

- `main` の `Deploy to GitHub Pages` を復旧するホットフィックス
- `test/RouteRegistration.test.tsx` の 5 箇所のアサーション `/発車の/` を `/出発の/` に置換
- 実装コードの変更は **0 件**

## 背景

失敗 run：<https://github.com/tomio2480/asahikawa-bus-departure/actions/runs/24599770429>

コミット `5ed8997`（「Update src/components/RouteRegistration.tsx」）で `NotifySettings` の成功トースト文言を「発車の」→「出発の」に変更したが、テスト側の正規表現が未追従となっていた。PR #95 マージ後（`4fb982b`）の main 上で `npm run test` が 2 件 fail し、Deploy 全体が `exit 1` で停止している。

## 変更内容

| 行 | 用法 | 修正前の挙動 |
|---|---|---|
| L1135 | `findByText(/発車の\s*15\s*分前/)` | **赤**（実害） |
| L1159 | `findByText(/発車の\s*20\s*分前/)` | **赤**（実害） |
| L1317 | `queryByText(/発車の.*/).not.toBeInTheDocument()` | 偶発的 pass（セマンティクス破壊）|
| L1439 | 同上 | 同上 |
| L1478 | 同上 | 同上 |

negative assertion 3 箇所（L1317, 1439, 1478）は、UI 側に「発車の」が存在しないため偶発的に pass していたが、「出発の ...」が出ていないことを検証したい意図に対して「発車の ...」を問い合わせていたため、セマンティクスが壊れていた。同時に整合させる。

## 補足

- PR #96（`feat/filter-reachable-stops`）には conflict 解消時に同一の 5 箇所更新が既に入っており、本 PR と差分内容は一致する。#96 側は後続で conflict 無しに取り込まれる見込み。
- L848 のコメント「本 PR で「発車」→「出発」に用語統一したため」は #92 起点の用語統一経緯を説明する正当なコメントのため保持する。

## Test plan

- [x] `npm run test` 全 419 件 Green（ローカル確認済み）
- [x] `npm run build` tsc + vite 通過（ローカル確認済み）
- [x] `grep "発車" test/RouteRegistration.test.tsx` が L848 のコメント 1 件のみ
- [ ] CI（Draft 作成後）緑を確認
- [ ] マージ後に main の Deploy to GitHub Pages run が緑で完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)