### PR TITLE
refactor(StopSearch): make query fully controlled

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,6 +207,16 @@ SELECT EXISTS (
 
 `StopSearch` は `ReachabilityFilter` prop を受け，候補サジェストをクラスタ単位で絞り込む．一方で `RouteRegistration` の送信時バリデーションは `searchStops(db, query, 100)` のようにフィルタ無し・limit 100 で広く名前一致を取り，「名称は存在するが到達不可能」のケースを明確に区別する（REVIEW_LESSONS 14）．
 
+### `StopSearch` は完全制御コンポーネント
+
+`StopSearch` は入力文字列 `query` を内部 state として持たず，親が保持する文字列をそのまま `value` prop として受け取る．候補選択やキー入力で発生する文字列変化は `onQueryChange` コールバックで親に通知する．親（`RouteRegistration`）の `FormState` が `fromStopQuery` / `toStopQuery` を含み，`StopSearchResult` の選択状態（`fromStop` / `toStop`）と一対で管理する（Issue #99）．
+
+半制御（内部 state ＋ `useEffect` による props→state 同期）の構成を採用しない．理由は以下のとおり．
+
+- `selectedStop` prop の変更を内部 `useState` に流し込む `useEffect` が必要になり，「内部発の `onSelect(null)` による `selectedStop=null` 遷移」と「外部発の `handleEdit` / `resetForm`」を区別するための escape-hatch（`suppressNextSelectedSyncRef` 等）が積み重なる．
+- 親の form state と子の query state が二重に存在することで，「選択済みのまま入力だけ書き換えて submit」の検知が状態遷移の順序に依存し，バグを誘発する．
+- React 公式「You Might Not Need an Effect」が推奨する「状態を親に上げて完全制御にする」パターンに整合する．
+
 ---
 
 ## 🕒 発車案内の生成

--- a/docs/REVIEW_LESSONS.md
+++ b/docs/REVIEW_LESSONS.md
@@ -1,6 +1,6 @@
 # 📘 過去レビューから抽出したセルフレビュー観点
 
-これまでの PR #92 / #95 / #96 / #97 / #98 で CodeRabbit・gemini-code-assist・ユーザーから受けた指摘を恒久化し，新規 PR を出す前のセルフレビューチェックリストとして機能させるための文書．実装エージェント・レビュー担当（自分自身含む）は，PR 作成前にここを最後に一読すること．
+これまでの PR #92 / #95 / #96 / #97 / #98 / Issue #99 で CodeRabbit・gemini-code-assist・ユーザーから受けた指摘を恒久化し，新規 PR を出す前のセルフレビューチェックリストとして機能させるための文書．実装エージェント・レビュー担当（自分自身含む）は，PR 作成前にここを最後に一読すること．
 
 本書は PR ごとに積まれる「移ろいやすい」知見を対象とする．設計判断の不変則は [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) に置き，本書で一定の汎用性が確認された事項をそちらへ蒸留する流れを取る．
 
@@ -136,7 +136,16 @@
   - `selectedStop` 経由の `useEffect` 同期と打鍵入力を同じテストで混ぜていないか．
 - **背景** ： `handleSearch` の中間 null 発火は `selectedStop` 無効化の仕様（入力が選択済みと乖離したら選択状態を破棄）を担う．この契約は変えない．
 
-### 17. セルフレビューは並列エージェントで多視点から行う
+### 17. 半制御コンポーネントを避け，入力系は完全制御に寄せる
+
+- **指摘例** （Issue #99， `src/components/StopSearch.tsx`）：内部で `useState<query>` を持ちつつ，`selectedStop` prop の変化を `useEffect` で同期するハイブリッド構造になっていた．さらに「内部発の `onSelect(null)` による selectedStop=null は query 反映させたくない」という要求に応えるため `suppressNextSelectedSyncRef` という escape-hatch が積まれ，意味論が不透明になっていた．
+- **対処パターン** ：React 公式「You Might Not Need an Effect」に従い，props→state 同期 useEffect を消す．query は親が完全に保持する完全制御コンポーネントにし，子は `value={query}` をそのまま input に渡すだけにする．親側（`RouteRegistration.tsx`）は form state に `fromStopQuery` / `toStopQuery` を持ち，`handleEdit` / `resetForm` 等の操作で stop と query を同一トランザクションで更新する．
+- **チェック観点** ：
+  - 子コンポーネント内に「親の prop を初期値として useState で受け，useEffect で prop 変化に追従」する構造があったら，それは半制御．親に state を上げて完全制御にできないか検討する．
+  - suppress フラグ / skip ref が必要になった時点で，状態の二重管理がバグを呼んでいるサイン．手続き的な打ち消しより構造を平らにする．
+- **テスト側の影響** ：完全制御化すると子単体のテストが `query` / `onQueryChange` を明示的に渡すか，state を保持する薄い wrapper（例: `ControlledStopSearch`）経由で render する必要がある．`<Component />` を `<ControlledComponent />` に置換するだけで旧挙動を再現できるよう wrapper を汎用化する．
+
+### 18. セルフレビューは並列エージェントで多視点から行う
 
 - **指摘例** （PR #98 ユーザー指示）：Draft PR 作成前のセルフレビューで，単一視点だと検知漏れが発生しやすい．a11y / 型安全 / デッドコード / テスト品質等の観点ごとに視点が独立しているため，並列実行で網羅性を上げられる．
 - **対処パターン** ：Draft 作成前に以下の 4 視点相当でエージェントを並列起動する．
@@ -155,6 +164,8 @@
 ### コード変更
 
 - [ ] `useEffect` で props→state 同期していないか． `useMemo` で派生値化できないか．
+- [ ] 子コンポーネント内で「prop を初期値とする `useState` + prop 変化を拾う `useEffect`」の半制御構造になっていないか．親に state を上げて完全制御にできないか．
+- [ ] 状態同期の打ち消しのために `suppress*Ref` / `skip*Ref` 等の escape-hatch を追加していないか．構造を平らにできないか．
 - [ ] WAI-ARIA 属性（`aria-expanded` / `aria-controls` / `aria-selected` 等）の値が，対応する DOM 描画条件と一致しているか．
 - [ ] 配列を扱うフィルタで `||` を使っていないか． `??` に置換できるか．
 - [ ] UI 文言を変えたら， `grep -rn '<旧文言>' test src` で残存が 0 件か．
@@ -205,3 +216,4 @@
 | #96 | 直通便で到達不能な組み合わせ除外 | クラスタ契約違反，`aria-expanded` 乖離，`useEffect` 同期排除，`??` vs `\|\|`，assertion の固定文字列化 |
 | #97 | main ホットフィックス（文言追従） | UI 文言変更時の test grep スイープ漏れ |
 | #98 | 経路登録 UX 改善（エラー・トースト・到達可能性告知） | `searchStops` limit のバリデーション用途誤用，エラー文末の句点揺れ，テスト名と本体の乖離，`handleSearch` 中間状態の `onSelect(null)` 契約 |
+| Issue #99 | `StopSearch` を完全制御コンポーネント化 | props→state 同期 `useEffect` の排除，`suppressNextSelectedSyncRef` escape-hatch の撤去，半制御 → 完全制御のテスト migration（`ControlledStopSearch` wrapper） |

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -563,9 +563,11 @@ export function RouteRegistration({
 					stop_name: toName,
 					clusterStopIds: [route.toStopId],
 				},
-				// 編集開始時は入力欄にも stop_name が入るため、query も同じ値で
-				// 初期化する（StopSearch からの onQueryChange 同期を待つ間の
-				// 整合性を保つ）。
+				// Issue #99 以降、StopSearch は完全制御コンポーネントであり、
+				// input.value は親が渡した query prop をそのまま反映する。
+				// 編集開始時は入力欄にも stop_name を表示するため、fromStop /
+				// toStop と fromStopQuery / toStopQuery を同一トランザクションで
+				// 更新し、フォーム状態の整合性を保つ。
 				fromStopQuery: fromName,
 				toStopQuery: toName,
 				walkMinutes: String(route.walkMinutes),
@@ -611,11 +613,12 @@ export function RouteRegistration({
 						<StopSearch
 							db={db}
 							label="乗車バス停"
-							onSelect={(stop) =>
-								updateForm((prev) => ({ ...prev, fromStop: stop }))
-							}
+							query={form.fromStopQuery}
 							onQueryChange={(q) =>
 								updateForm((prev) => ({ ...prev, fromStopQuery: q }))
+							}
+							onSelect={(stop) =>
+								updateForm((prev) => ({ ...prev, fromStop: stop }))
 							}
 							selectedStop={form.fromStop}
 							reachabilityFilter={fromStopFilter}
@@ -623,11 +626,12 @@ export function RouteRegistration({
 						<StopSearch
 							db={db}
 							label="降車バス停"
-							onSelect={(stop) =>
-								updateForm((prev) => ({ ...prev, toStop: stop }))
-							}
+							query={form.toStopQuery}
 							onQueryChange={(q) =>
 								updateForm((prev) => ({ ...prev, toStopQuery: q }))
+							}
+							onSelect={(stop) =>
+								updateForm((prev) => ({ ...prev, toStop: stop }))
 							}
 							selectedStop={form.toStop}
 							reachabilityFilter={toStopFilter}

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -20,10 +20,28 @@ type StopSearchProps = {
 	/** 入力欄のラベル */
 	label: string;
 	/**
+	 * Issue #99: 完全制御コンポーネントとしての query state。
+	 * 親が保持する string をそのまま input の value として反映する。
+	 * 内部 useState による二重管理と props→state 同期 useEffect を
+	 * 排し、handleEdit / resetForm 等の親発の query 書き換えも
+	 * 単純な setState で完結させる（React 公式「You Might Not Need
+	 * an Effect」の推奨形）。
+	 */
+	query: string;
+	/**
+	 * query 文字列が変化したときのコールバック。
+	 *
+	 * ユーザーのキー入力・候補選択のいずれでも最新の query を
+	 * 親に通知する。親は「選択が無効だがユーザーは文字を入力
+	 * している」状態を検出し、エラー文言の分岐（「選択して
+	 * ください」/「存在しません」/「乗り換えなしで到達できま
+	 * せん」/「候補から選択してください」）に使う。
+	 */
+	onQueryChange: (query: string) => void;
+	/**
 	 * バス停の選択状態が変化したときのコールバック。
 	 *
-	 * - 候補クリック / Enter 押下 / selectedStop prop からの初期化時は
-	 *   `StopSearchResult` で呼び出す。
+	 * - 候補クリック / Enter 押下時は `StopSearchResult` で呼び出す。
 	 * - 選択済みの状態で入力値が `selectedStop.stop_name` と乖離した場合は
 	 *   `null` で呼び出し、親側の選択状態を無効化することを依頼する。
 	 *
@@ -32,17 +50,7 @@ type StopSearchProps = {
 	 * 選択の有効/無効は常に本コールバックの契約で一元化する。
 	 */
 	onSelect: (stop: StopSearchResult | null) => void;
-	/**
-	 * 入力欄の query 文字列が変化したときのコールバック。
-	 *
-	 * ユーザーのキー入力・候補選択・`selectedStop` prop 経由の同期の
-	 * いずれでも最新の query を親に通知する。親は「選択が無効だが
-	 * ユーザーは文字を入力している」状態を検出し、エラー文言の分岐
-	 * （「選択してください」/「存在しません」/「乗り換えなしで到達
-	 * できません」/「候補から選択してください」）に使う。
-	 */
-	onQueryChange?: (query: string) => void;
-	/** 選択済みのバス停（外部から制御する場合） */
+	/** 選択済みのバス停（「選択済み状態で入力値が乖離」検出に使う） */
 	selectedStop?: StopSearchResult | null;
 	/** placeholder テキスト */
 	placeholder?: string;
@@ -58,14 +66,14 @@ type StopSearchProps = {
 export function StopSearch({
 	db,
 	label,
-	onSelect,
+	query,
 	onQueryChange,
+	onSelect,
 	selectedStop = null,
 	placeholder = "バス停名を入力",
 	reachabilityFilter,
 }: StopSearchProps) {
 	const id = useId();
-	const [query, setQuery] = useState(selectedStop?.stop_name ?? "");
 	const [isOpen, setIsOpen] = useState(false);
 	const [activeIndex, setActiveIndex] = useState(-1);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -87,59 +95,17 @@ export function StopSearch({
 	// （coderabbitai #96 指摘）。
 	const isListboxOpen = isOpen && results.length > 0;
 
-	// 本コンポーネント自身が発する onSelect(null) による selectedStop=null
-	// への遷移と、外部起因の selectedStop 変更（handleEdit / resetForm 等）を
-	// 区別するためのフラグ。前者では query を空に戻したくないが、後者では
-	// query を新しい値に同期したい。
-	//
-	// 内部起因（ユーザーが選択済みの入力を書き換えた）の場合だけこのフラグを
-	// 立て、直後に発火する selectedStop 同期 useEffect でスキップさせる。
-	// これにより、選択後に input を書き換えたときユーザーの打鍵がそのまま
-	// 残り、到達不能・存在しないバス停で submit したときの再検証ガードも
-	// 正しく働くようになる。
-	const suppressNextSelectedSyncRef = useRef(false);
-
-	// 親が渡す onQueryChange は毎レンダ新規生成されるケースが多いため、
-	// 依存配列に直接入れると useEffect / useCallback が毎レンダ再実行・
-	// 再生成されてしまう（REVIEW_LESSONS #1 の派生値同期アンチパターンに
-	// 似た無駄を生む）。ref で最新関数を保持し、依存配列からは除外する
-	// useEventCallback パターンで切り離す。
-	const onQueryChangeRef = useRef(onQueryChange);
-	useEffect(() => {
-		onQueryChangeRef.current = onQueryChange;
-	}, [onQueryChange]);
-
-	// query を更新すると同時に親の onQueryChange にも通知するヘルパー。
-	// 空の依存配列で identity を固定し、handleSearch / handleSelect /
-	// selectedStop 同期 effect いずれから呼ばれても無駄な再生成を避ける。
-	const updateQuery = useCallback((newQuery: string) => {
-		setQuery(newQuery);
-		onQueryChangeRef.current?.(newQuery);
-	}, []);
-
-	// 外部から selectedStop が変更された場合に入力欄を同期する。
-	// 内部起因（handleSearch の onSelect(null)）経由の selectedStop=null
-	// 遷移ではスキップし、ユーザーが打鍵した中間状態の query を保持する。
-	useEffect(() => {
-		if (suppressNextSelectedSyncRef.current) {
-			suppressNextSelectedSyncRef.current = false;
-			return;
-		}
-		updateQuery(selectedStop?.stop_name ?? "");
-	}, [selectedStop, updateQuery]);
-
 	const handleSearch = useCallback(
 		(value: string) => {
-			updateQuery(value);
+			onQueryChange(value);
 			setActiveIndex(-1);
 			// 選択済み状態で入力値が選択 stop の名称と乖離したら、親側の
 			// 選択状態を無効化する。これにより「選択後に入力だけ書き換えて
 			// submit」された場合でも、親の form state が null に戻り、
 			// 実在性・到達可能性の再検証（= submit ガード）が正しく走る。
-			// 直後の useEffect が selectedStop=null を受けて query を空に
-			// 戻さないよう、suppress フラグを立ててから onSelect(null) を呼ぶ。
+			// 完全制御化（Issue #99）で query が外部 state になったため、
+			// 内部 state を書き戻す必要がなく suppress フラグは不要になった。
 			if (selectedStop && value !== selectedStop.stop_name) {
-				suppressNextSelectedSyncRef.current = true;
 				onSelect(null);
 			}
 			if (value.trim() === "") {
@@ -149,17 +115,17 @@ export function StopSearch({
 			// results は派生値として自動再計算されるため、ここでは開閉のみ制御する。
 			setIsOpen(true);
 		},
-		[selectedStop, onSelect, updateQuery],
+		[selectedStop, onSelect, onQueryChange],
 	);
 
 	const handleSelect = useCallback(
 		(stop: StopSearchResult) => {
-			updateQuery(stop.stop_name);
+			onQueryChange(stop.stop_name);
 			setIsOpen(false);
 			setActiveIndex(-1);
 			onSelect(stop);
 		},
-		[onSelect, updateQuery],
+		[onSelect, onQueryChange],
 	);
 
 	const handleKeyDown = useCallback(

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -339,10 +339,11 @@ describe("StopSearch コンポーネント", () => {
 		expect(onSelect).toHaveBeenCalledWith(null);
 	});
 
-	// selectedStop を渡して初期マウントした直後、useEffect 経由で query が
-	// selectedStop.stop_name に同期されるだけで、onSelect(null) が誤発火しない
-	// ことを確認する。ここで null が通知されると親の form state を破壊する
-	// ループになるため、マウント直後の防御的テストとして残す。
+	// selectedStop を渡して初期マウントした直後、ControlledStopSearch wrapper の
+	// useState 初期化子が selectedStop.stop_name を query に取り込んだ状態で
+	// onSelect(null) が誤発火しないことを確認する。ここで null が通知されると
+	// 親の form state を破壊するループになるため、マウント直後の防御的テスト
+	// として残す。
 	it("selectedStop 初期マウント時に onSelect(null) は呼ばれない", () => {
 		const onSelect = vi.fn();
 		const selected: StopSearchResult = {

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -25,6 +25,19 @@ import type { GtfsData } from "../src/types/gtfs";
  * 薄い wrapper を経由させる。初期値は selectedStop.stop_name から
  * 引き出し、旧挙動（選択済み stop を渡すと input に名称が表示される）を
  * そのまま再現する。
+ *
+ * **スコープの制約**（gemini-code-assist #102 レビュー対応）：
+ * 本 wrapper は「初回マウント時のみ `selectedStop.stop_name` を query の
+ * 初期値として取り込み、以降は query と selectedStop を同期しない」最小
+ * 変換器として設計している。`useEffect` による props→state 同期は敢えて
+ * 持たない（Issue #99 のリファクタ対象そのものであり、wrapper に戻すと
+ * 本末転倒になるため）。
+ *
+ * したがって、初回マウント後に `selectedStop` prop を差し替えるような
+ * テスト（`rerender` で `selectedStop` だけ変更するケース）には対応しない。
+ * 将来そのようなテストが必要になった場合は、本 wrapper を拡張せず、
+ * `StopSearch` を直接使用し、親テストコンポーネント側で `query` と
+ * `selectedStop` をまとめて制御する形（新 API 本来の使い方）で対応する。
  */
 type ControlledStopSearchProps = Omit<
 	ComponentProps<typeof StopSearch>,

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { type ComponentProps, useState } from "react";
 import initSqlJs from "sql.js";
 import {
 	afterEach,
@@ -14,6 +15,41 @@ import { StopSearch } from "../src/components/StopSearch";
 import { createSchema, loadGtfsData } from "../src/lib/gtfs-loader";
 import type { StopSearchResult } from "../src/lib/stop-search";
 import type { GtfsData } from "../src/types/gtfs";
+
+/**
+ * Issue #99: StopSearch を完全制御コンポーネント化した後のテスト用ラッパー。
+ *
+ * 従来（内部 useState 版）のテストは query/onQueryChange を意識せずに
+ * `<StopSearch ... />` を直接レンダリングしていた。新 API では親が
+ * query を保持する契約になったため、テスト側も query state を保持する
+ * 薄い wrapper を経由させる。初期値は selectedStop.stop_name から
+ * 引き出し、旧挙動（選択済み stop を渡すと input に名称が表示される）を
+ * そのまま再現する。
+ */
+type ControlledStopSearchProps = Omit<
+	ComponentProps<typeof StopSearch>,
+	"query" | "onQueryChange"
+> & {
+	initialQuery?: string;
+};
+
+function ControlledStopSearch({
+	initialQuery,
+	selectedStop,
+	...rest
+}: ControlledStopSearchProps) {
+	const [query, setQuery] = useState(
+		initialQuery ?? selectedStop?.stop_name ?? "",
+	);
+	return (
+		<StopSearch
+			{...rest}
+			selectedStop={selectedStop}
+			query={query}
+			onQueryChange={setQuery}
+		/>
+	);
+}
 
 const testStops: GtfsData["stops"] = [
 	{
@@ -70,20 +106,24 @@ afterEach(() => {
 describe("StopSearch コンポーネント", () => {
 	it("ラベルが表示される", () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 		expect(screen.getByText("乗車バス停")).toBeInTheDocument();
 	});
 
 	it("プレースホルダーが表示される", () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 		expect(screen.getByPlaceholderText("バス停名を入力")).toBeInTheDocument();
 	});
 
 	it("カスタムプレースホルダーを設定できる", () => {
 		const onSelect = vi.fn();
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="乗車バス停"
 				onSelect={onSelect}
@@ -93,9 +133,61 @@ describe("StopSearch コンポーネント", () => {
 		expect(screen.getByPlaceholderText("検索...")).toBeInTheDocument();
 	});
 
+	it("query prop が input の value として反映される（fully controlled API）", () => {
+		// Issue #99: StopSearch は props→state 同期 useEffect を排した
+		// 完全制御コンポーネントとする。親が保持する query state がそのまま
+		// input の value になり、内部 useState を介さないことを保証する。
+		const onSelect = vi.fn();
+		const onQueryChange = vi.fn();
+		render(
+			<StopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				query="旭川駅"
+				onQueryChange={onQueryChange}
+			/>,
+		);
+		const input = screen.getByRole("combobox") as HTMLInputElement;
+		expect(input.value).toBe("旭川駅");
+	});
+
+	it("query prop の変更が input の value に即時反映される（fully controlled API）", () => {
+		// Issue #99: 親が query を書き換えた場合（handleEdit / resetForm の
+		// 親側 setFormState 経由）、次の render で input.value が新しい値に
+		// 反映される。内部 state を介さないため、同期 useEffect も
+		// suppress フラグも不要になる。
+		const onSelect = vi.fn();
+		const onQueryChange = vi.fn();
+		const { rerender } = render(
+			<StopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				query=""
+				onQueryChange={onQueryChange}
+			/>,
+		);
+		const input = screen.getByRole("combobox") as HTMLInputElement;
+		expect(input.value).toBe("");
+
+		rerender(
+			<StopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				query="市役所前"
+				onQueryChange={onQueryChange}
+			/>,
+		);
+		expect(input.value).toBe("市役所前");
+	});
+
 	it("テキスト入力で検索結果が表示される", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "旭川");
@@ -107,7 +199,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("該当なしの場合はドロップダウンが表示されない", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "札幌");
@@ -117,7 +211,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("検索結果をクリックして選択できる", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "市役所");
@@ -136,7 +232,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("ArrowDown/ArrowUp でフォーカスを移動できる", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "旭川");
@@ -152,7 +250,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("Enter キーで選択できる", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "旭川");
@@ -165,7 +265,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("Escape キーでドロップダウンが閉じる", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "旭川");
@@ -183,7 +285,7 @@ describe("StopSearch コンポーネント", () => {
 			clusterStopIds: ["test:S001"],
 		};
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="乗車バス停"
 				onSelect={onSelect}
@@ -209,7 +311,7 @@ describe("StopSearch コンポーネント", () => {
 			clusterStopIds: ["test:S001"],
 		};
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="乗車バス停"
 				onSelect={onSelect}
@@ -236,7 +338,7 @@ describe("StopSearch コンポーネント", () => {
 			clusterStopIds: ["test:S001"],
 		};
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="乗車バス停"
 				onSelect={onSelect}
@@ -249,7 +351,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("入力を空にするとドロップダウンが閉じる", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "旭川");
@@ -261,7 +365,9 @@ describe("StopSearch コンポーネント", () => {
 
 	it("aria-expanded が正しく設定される", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		expect(input).toHaveAttribute("aria-expanded", "false");
@@ -275,7 +381,9 @@ describe("StopSearch コンポーネント", () => {
 		// WAI-ARIA combobox パターンに違反する。描画条件と aria-expanded は
 		// 「候補が 1 件以上かつユーザーが閉じていない」の派生値で一元化する。
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "該当しない文字列xyz");
@@ -290,7 +398,7 @@ describe("StopSearch コンポーネント", () => {
 		const onSelect = vi.fn();
 		render(
 			<div>
-				<StopSearch db={db} label="乗車バス停" onSelect={onSelect} />
+				<ControlledStopSearch db={db} label="乗車バス停" onSelect={onSelect} />
 				<button type="button">外側ボタン</button>
 			</div>,
 		);
@@ -384,7 +492,9 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 
 	it("reachabilityFilter 未指定時は全候補を表示する", async () => {
 		const onSelect = vi.fn();
-		render(<StopSearch db={db} label="降車バス停" onSelect={onSelect} />);
+		render(
+			<ControlledStopSearch db={db} label="降車バス停" onSelect={onSelect} />,
+		);
 
 		const input = screen.getByRole("combobox");
 		await userEvent.type(input, "停");
@@ -397,7 +507,7 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 	it("reachableFromOrigin 指定時は origin から直通で到達可能な候補のみ表示する", async () => {
 		const onSelect = vi.fn();
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="降車バス停"
 				onSelect={onSelect}
@@ -417,7 +527,7 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 	it("reachableToDestination 指定時は destination に直通で到達できる候補のみ表示する", async () => {
 		const onSelect = vi.fn();
 		render(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="乗車バス停"
 				onSelect={onSelect}
@@ -437,7 +547,7 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 	it("reachabilityFilter の変更時にドロップダウン表示が追従する", async () => {
 		const onSelect = vi.fn();
 		const { rerender } = render(
-			<StopSearch db={db} label="降車バス停" onSelect={onSelect} />,
+			<ControlledStopSearch db={db} label="降車バス停" onSelect={onSelect} />,
 		);
 
 		const input = screen.getByRole("combobox");
@@ -446,7 +556,7 @@ describe("StopSearch（到達可能性フィルタ）", () => {
 
 		// フィルタを追加して再描画 → D は除外されるべき
 		rerender(
-			<StopSearch
+			<ControlledStopSearch
 				db={db}
 				label="降車バス停"
 				onSelect={onSelect}


### PR DESCRIPTION
## Summary

- `StopSearch` の半制御構造（内部 `useState<query>` + `selectedStop` 同期 `useEffect` + `suppressNextSelectedSyncRef` escape-hatch）を撤去し、親が query を保持する完全制御コンポーネントへ移行する（Issue #99）．
- 親 `RouteRegistration` の `FormState` 既存フィールド `fromStopQuery` / `toStopQuery` を `<StopSearch query={...} />` に配線し、stop 選択状態と query を同一トランザクションで更新する既存の実装に整合させる．
- テストは `ControlledStopSearch` wrapper を導入して既存 20 件を移行．新 API 契約（`query` prop が `input.value` に反映される）を検証する Red テスト 2 件を先に入れて TDD サイクルで実装した．

## Why

`suppressNextSelectedSyncRef` の escape-hatch は「内部発の `onSelect(null)` による `selectedStop=null` 遷移では query を空に戻したくないが、外部発の `handleEdit` / `resetForm` では同期したい」という矛盾した要求を、同期 `useEffect` を温存したまま成り立たせるための手続き的な打ち消しだった．React 公式「You Might Not Need an Effect」が推奨する「状態を親に上げて完全制御にする」方針に寄せることで、状態の二重管理と escape-hatch の両方を一気に消せる．

## Changes

- `src/components/StopSearch.tsx`：
  - `query: string` / `onQueryChange: (q) => void` を必須 prop 化
  - 内部 `useState<query>`、同期 `useEffect`、`suppressNextSelectedSyncRef`、`updateQuery` / `onQueryChangeRef` ヘルパーを撤去
  - `handleSearch` / `handleSelect` は `onQueryChange` を直接呼ぶだけのシンプルな形に整理
- `src/components/RouteRegistration.tsx`：2 つの `<StopSearch>` に `query={form.fromStopQuery}` / `query={form.toStopQuery}` を渡す．`handleEdit` のコメントを完全制御モデルに合わせて更新
- `test/StopSearch.test.tsx`：`ControlledStopSearch` wrapper を導入し、既存 20 件を wrapper 経由に移行．新 API 検証テスト 2 件（`query` prop が input value に反映される／prop 変更が即時反映される）を追加
- `docs/ARCHITECTURE.md`：「`StopSearch` は完全制御コンポーネント」セクションを追加
- `docs/REVIEW_LESSONS.md`：新規カテゴリ #17「半制御コンポーネントを避け，入力系は完全制御に寄せる」を追加．チェックリスト・参照過去 PR 表も更新

## Test plan

- [ ] `npm test`：469 tests pass（ローカル確認済み）
- [ ] `npm run build`：exit 0、tsc + vite build 通過（ローカル確認済み）
- [ ] CI の Deploy / Lint / CodeQL 等が緑
- [ ] 手動検証：経路登録フォームで選択済みバス停を書き換えると `onSelect(null)` で選択無効化され、実在性・到達可能性の再検証が走る
- [ ] 手動検証：編集ボタン押下で入力欄が正しい stop_name で埋まり、reset で空に戻る

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ストップ検索コンポーネントのアーキテクチャドキュメント更新
  * React コンポーネント設計のベストプラクティス文書拡充

* **Refactor**
  * ストップ検索機能の状態管理を改善し、入力と選択の同期制御をより堅牢に実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->