### PR TITLE
feat(RouteRegistration): disable form inputs during submit (Issue #103)

### DIFF
--- a/docs/REVIEW_LESSONS.md
+++ b/docs/REVIEW_LESSONS.md
@@ -162,8 +162,8 @@
   - さらに既存コードでは，キャンセル・一覧通知トグル・編集・削除ボタンが `submitting || togglingRouteId !== null` を直書きしているのに対し，登録/更新ボタンのみ `submitting` 単独判定という非対称があり，「トグル処理中でも登録ボタンだけ押せる」状態が生じていた．
 - **対処パターン** ：
   - `isFormLocked = submitting || togglingRouteId !== null` のような派生値を 1 箇所で定義し，入力系・キャンセル・登録/更新・一覧のトグル/編集/削除・子コンポーネント（`NotifySettings` 等）の disabled 条件をすべて同値に揃える．子コンポーネント側も個別フラグ（`submitting` / `togglingRouteId`）ではなく派生値（`isFormLocked`）を受け取る契約にすることで，重複ロジックと対称性の崩れをまとめて解消する．
-  - `StopSearch` のような composite widget は `disabled` 化に合わせて開いている listbox を閉じる（WAI-ARIA：「操作不能なのに listbox が見えている」状態を作らない）．false→true 遷移のみで発火する `useEffect` で実装する．
-- **補足** ： ここで使う `useEffect` は「props の変化に応じた内部 state の一回性リセット」であり，Issue #99 で排除した「props→state 同期」（双方向・常時追従）とは別物．JSDoc で意図を明記して混同を防ぐ．
+  - `StopSearch` のような composite widget は `disabled` 化に合わせて開いている listbox を閉じる（WAI-ARIA：「操作不能なのに listbox が見えている」状態を作らない）．実装は listbox の描画条件を `const isListboxOpen = !disabled && isOpen && results.length > 0` のような派生値で表現し，`useEffect` による内部 state の書き戻しは行わない．
+- **補足** ： 「`disabled` 遷移で内部 state をリセットする `useEffect`」は一見「一回性の片方向反映」に見えるが，描画条件側に `!disabled` を AND するだけで同じ結果になる．`useEffect` を書く前に「派生値で表現できないか」を最初に検討すること（PR #104 gemini-code-assist 指摘）．Issue #99 で排除した「props→state 同期」（双方向・常時追従）を避けるのはもちろん，片方向であっても React 公式「You Might Not Need an Effect」の観点で `useEffect` は可能な限り減らす方針を徹底する．
 - **チェック観点** ：
   - 同じ真偽条件式（`a || b !== null` 等）が 3 箇所以上に重複していないか．派生値に束ねられないか．
   - フォーム送信・トグル処理などの async 操作中に，他の入力系が触れる状態になっていないか．

--- a/docs/REVIEW_LESSONS.md
+++ b/docs/REVIEW_LESSONS.md
@@ -162,12 +162,18 @@
   - さらに既存コードでは，キャンセル・一覧通知トグル・編集・削除ボタンが `submitting || togglingRouteId !== null` を直書きしているのに対し，登録/更新ボタンのみ `submitting` 単独判定という非対称があり，「トグル処理中でも登録ボタンだけ押せる」状態が生じていた．
 - **対処パターン** ：
   - `isFormLocked = submitting || togglingRouteId !== null` のような派生値を 1 箇所で定義し，入力系・キャンセル・登録/更新・一覧のトグル/編集/削除・子コンポーネント（`NotifySettings` 等）の disabled 条件をすべて同値に揃える．子コンポーネント側も個別フラグ（`submitting` / `togglingRouteId`）ではなく派生値（`isFormLocked`）を受け取る契約にすることで，重複ロジックと対称性の崩れをまとめて解消する．
-  - `StopSearch` のような composite widget は `disabled` 化に合わせて開いている listbox を閉じる（WAI-ARIA：「操作不能なのに listbox が見えている」状態を作らない）．実装は listbox の描画条件を `const isListboxOpen = !disabled && isOpen && results.length > 0` のような派生値で表現し，`useEffect` による内部 state の書き戻しは行わない．
-- **補足** ： 「`disabled` 遷移で内部 state をリセットする `useEffect`」は一見「一回性の片方向反映」に見えるが，描画条件側に `!disabled` を AND するだけで同じ結果になる．`useEffect` を書く前に「派生値で表現できないか」を最初に検討すること（PR #104 gemini-code-assist 指摘）．Issue #99 で排除した「props→state 同期」（双方向・常時追従）を避けるのはもちろん，片方向であっても React 公式「You Might Not Need an Effect」の観点で `useEffect` は可能な限り減らす方針を徹底する．
+  - 親の async 処理（例： permission 要求の `await`）は，`setSubmitting(true)` より **前** ではなく **後** に置いて try ブロック内に含める．前に置くと「プロンプト表示中は `isFormLocked=false`」の空白期間ができて入力レースが残り，さらに async の reject が下の try/catch 外に漏れる．`setSubmitting(true) → try { await permission; await save; } finally { setSubmitting(false); }` の順にする．
+  - `StopSearch` のような composite widget を `disabled` 化するときは，listbox を閉じる責務を「派生値」と「`useEffect` による内部 state リセット」の **二段構え** で担保する．
+    - 派生値 `const isListboxOpen = !disabled && isOpen && results.length > 0` は， `disabled=false→true` のレンダリング段階から listbox を非表示にする（`useEffect` は render 後に走るため 1 フレーム描画が残る問題を防ぐ）．
+    - `useEffect(() => { if (disabled) setIsOpen(false); }, [disabled])` は， `disabled=true→false` の逆遷移時に内部 `isOpen` が保持されたまま `results` が残っていて listbox が自動再表示される問題を防ぐ（再表示にはユーザーの明示操作（focus/入力）を要求する契約）．
+    - 片方だけだと異なる遷移方向のバグが残る（gemini-code-assist が 1 フレーム問題を，coderabbitai が逆遷移再表示問題を別々に指摘）．
+- **補足** ： `useEffect` を書くときは「派生値で表現できないか」を最初に検討する（React 公式「You Might Not Need an Effect」）．ただし本件の逆遷移リセットのように，描画条件だけでは「内部 state の保持」に起因する問題が残るケースもある．その場合は派生値で描画を保証したうえで， `useEffect` で内部 state を一方向にリセットして補う．両者が担う責務（1 フレーム問題 vs 逆遷移時の再表示）を JSDoc に明記して混同を防ぐ．Issue #99 で排除した「props→state 同期」（双方向・常時追従）とは依然として別物である．
 - **チェック観点** ：
   - 同じ真偽条件式（`a || b !== null` 等）が 3 箇所以上に重複していないか．派生値に束ねられないか．
   - フォーム送信・トグル処理などの async 操作中に，他の入力系が触れる状態になっていないか．
+  - フォーム送信ハンドラで， `setSubmitting(true)` より前に `await`（permission 要求等）していないか．プロンプト表示中の入力レースと reject の捕捉漏れの温床．
   - disabled になった composite widget が「見える」けれど「操作できない」中途半端な状態を作っていないか．
+  - disabled 化の実装が「 `disabled=false→true` 遷移時の描画フレーム」と「 `disabled=true→false` 逆遷移時の内部 state 保持」の両方向を閉じているか．
 
 ---
 

--- a/docs/REVIEW_LESSONS.md
+++ b/docs/REVIEW_LESSONS.md
@@ -155,6 +155,20 @@
   - テストの assertion 強度（キーワード選言の不在，冒頭フレーズ固定の堅牢性，同時検証の網羅）．
 - **チェック観点** ：セルフレビューが 1 パスで済んでいる場合，視点の独立性が担保されているか疑う．レビュー結果を本文書のカテゴリに還元する．
 
+### 19. フォーム全体の無効化ポリシーを派生値で束ねる
+
+- **指摘例** （PR #102 gemini-code-assist / Issue #103，`src/components/RouteRegistration.tsx`）：
+  - 入力系 3 種（`StopSearch` × 2 / 徒歩時間 `input` / 通知 `checkbox`）が submit pending 中に disabled 化されておらず，`await` 解決後の `resetForm` でユーザーの新しい入力が吹き飛ぶレースがあった．
+  - さらに既存コードでは，キャンセル・一覧通知トグル・編集・削除ボタンが `submitting || togglingRouteId !== null` を直書きしているのに対し，登録/更新ボタンのみ `submitting` 単独判定という非対称があり，「トグル処理中でも登録ボタンだけ押せる」状態が生じていた．
+- **対処パターン** ：
+  - `isFormLocked = submitting || togglingRouteId !== null` のような派生値を 1 箇所で定義し，入力系・キャンセル・登録/更新・一覧のトグル/編集/削除・子コンポーネント（`NotifySettings` 等）の disabled 条件をすべて同値に揃える．子コンポーネント側も個別フラグ（`submitting` / `togglingRouteId`）ではなく派生値（`isFormLocked`）を受け取る契約にすることで，重複ロジックと対称性の崩れをまとめて解消する．
+  - `StopSearch` のような composite widget は `disabled` 化に合わせて開いている listbox を閉じる（WAI-ARIA：「操作不能なのに listbox が見えている」状態を作らない）．false→true 遷移のみで発火する `useEffect` で実装する．
+- **補足** ： ここで使う `useEffect` は「props の変化に応じた内部 state の一回性リセット」であり，Issue #99 で排除した「props→state 同期」（双方向・常時追従）とは別物．JSDoc で意図を明記して混同を防ぐ．
+- **チェック観点** ：
+  - 同じ真偽条件式（`a || b !== null` 等）が 3 箇所以上に重複していないか．派生値に束ねられないか．
+  - フォーム送信・トグル処理などの async 操作中に，他の入力系が触れる状態になっていないか．
+  - disabled になった composite widget が「見える」けれど「操作できない」中途半端な状態を作っていないか．
+
 ---
 
 ## セルフレビューチェックリスト
@@ -172,6 +186,7 @@
 - [ ] 定数値（閾値・分数・回数等）を 2 箇所以上に直書きしていないか．
 - [ ] `new SQL.Database()` の直前・直後で， `close()` の対応が取れているか．
 - [ ] Enter key handler と onClick handler で，busy / validity ガードが対称か．
+- [ ] フォーム全体の disabled 条件（submit 中 / 別の async 処理中）が派生値で束ねられ，入力系・ボタン・子コンポーネントすべてで同値を参照しているか．
 - [ ] `useMemo` で計算した値を別関数で再計算していないか．
 - [ ] 存在判定・厳密一致判定（バリデーション目的）で `searchStops` を呼ぶ箇所は， `limit=100` を明示しているか（`undefined` プレースホルダを残していないか）．
 - [ ] ユーザー向けエラーメッセージ（生成関数・定数・直接記述）の全箇所で，句点有無・体言止め・敬体が揃っているか．
@@ -217,3 +232,4 @@
 | #97 | main ホットフィックス（文言追従） | UI 文言変更時の test grep スイープ漏れ |
 | #98 | 経路登録 UX 改善（エラー・トースト・到達可能性告知） | `searchStops` limit のバリデーション用途誤用，エラー文末の句点揺れ，テスト名と本体の乖離，`handleSearch` 中間状態の `onSelect(null)` 契約 |
 | Issue #99 | `StopSearch` を完全制御コンポーネント化 | props→state 同期 `useEffect` の排除，`suppressNextSelectedSyncRef` escape-hatch の撤去，半制御 → 完全制御のテスト migration（`ControlledStopSearch` wrapper） |
+| Issue #103 | 経路登録フォーム送信中の入力系無効化 | 派生値 `isFormLocked` によるフォーム全体 disabled の一本化，登録/更新ボタンの対称化，`StopSearch` の `disabled` prop 追加（disabled 化で listbox を閉じる） |

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -209,10 +209,12 @@ type NotifySettingsProps = {
 	notifyBeforeMinutes: number;
 	/** 通知タイミングを永続化するハンドラ */
 	setNotifyBeforeMinutes: (value: number) => void;
-	/** フォーム送信中かどうか（設定ボタンの disabled 制御） */
-	submitting: boolean;
-	/** トグル処理中の経路 ID（設定ボタンの disabled 制御） */
-	togglingRouteId: number | null;
+	/**
+	 * Issue #103: フォーム全体が操作禁止状態か（設定ボタンと Enter 経路を
+	 * 同じ busy 条件でガードするため、個別フラグではなく派生値で受け取る）。
+	 * 親の `isFormLocked = submitting || togglingRouteId !== null` を直接渡す。
+	 */
+	isFormLocked: boolean;
 	/** 通知パーミッション要求 */
 	onRequestNotificationPermission?: () => Promise<NotificationPermission>;
 	/** 現在の通知パーミッション */
@@ -232,8 +234,7 @@ type NotifySettingsProps = {
 function NotifySettings({
 	notifyBeforeMinutes,
 	setNotifyBeforeMinutes,
-	submitting,
-	togglingRouteId,
+	isFormLocked,
 	onRequestNotificationPermission,
 	notifyPermission,
 }: NotifySettingsProps) {
@@ -251,7 +252,7 @@ function NotifySettings({
 	 * busy / validity を明示ガードし、Enter 経路でも誤トースト表示を防ぐ。
 	 */
 	const commitNotifyInput = () => {
-		if (submitting || togglingRouteId !== null) return;
+		if (isFormLocked) return;
 		if (!canCommit) return;
 		const result = internalCommit();
 		if (result.ok) {
@@ -310,7 +311,7 @@ function NotifySettings({
 					type="button"
 					className="btn btn-xs btn-primary"
 					onClick={commitNotifyInput}
-					disabled={!canCommit || submitting || togglingRouteId !== null}
+					disabled={!canCommit || isFormLocked}
 					aria-label="通知タイミングを設定"
 				>
 					設定
@@ -395,6 +396,24 @@ export function RouteRegistration({
 	// 「登録」ボタンが通知 ON/OFF のたびに「保存中...」へ切り替わるなどの
 	// 表示揺れを防ぐ。トグル処理は複数同時実行させないため null | number で十分。
 	const [togglingRouteId, setTogglingRouteId] = useState<number | null>(null);
+
+	/**
+	 * Issue #103: フォーム全体を操作禁止にすべき状態を一本化した派生値。
+	 *
+	 * - `submitting`：フォーム送信（handleSubmit / handleDelete）中。
+	 * - `togglingRouteId !== null`：一覧側の通知 ON/OFF 切替 await 中。
+	 *
+	 * 既存コードではキャンセル・一覧通知トグル・編集・削除ボタン・
+	 * NotifySettings 設定ボタンが各々 `submitting || togglingRouteId !== null`
+	 * を直書きしていたが、同じ条件式の重複は派生値に束ねる。
+	 * 登録/更新ボタンは従来 `submitting` のみで togglingRouteId を参照して
+	 * いなかった非対称を、本値で揃える（ユーザー指定）。
+	 *
+	 * 入力系 3 種（乗車/降車 StopSearch × 2・徒歩時間 input・通知 checkbox）
+	 * も本値で disabled 化することで、await 解決後の resetForm によってユーザー
+	 * の新規入力が吹き飛ぶレースを排除する。
+	 */
+	const isFormLocked = submitting || togglingRouteId !== null;
 
 	const { showToast } = useToast();
 
@@ -622,6 +641,7 @@ export function RouteRegistration({
 							}
 							selectedStop={form.fromStop}
 							reachabilityFilter={fromStopFilter}
+							disabled={isFormLocked}
 						/>
 						<StopSearch
 							db={db}
@@ -635,6 +655,7 @@ export function RouteRegistration({
 							}
 							selectedStop={form.toStop}
 							reachabilityFilter={toStopFilter}
+							disabled={isFormLocked}
 						/>
 					</div>
 					{/*
@@ -665,6 +686,7 @@ export function RouteRegistration({
 								}))
 							}
 							placeholder="10"
+							disabled={isFormLocked}
 						/>
 					</div>
 					<div className="form-control">
@@ -679,6 +701,7 @@ export function RouteRegistration({
 										notifyEnabled: e.target.checked,
 									}))
 								}
+								disabled={isFormLocked}
 							/>
 							<span className="label-text">通知</span>
 						</label>
@@ -700,7 +723,7 @@ export function RouteRegistration({
 								type="button"
 								className="btn btn-ghost"
 								onClick={resetForm}
-								disabled={submitting || togglingRouteId !== null}
+								disabled={isFormLocked}
 							>
 								キャンセル
 							</button>
@@ -708,7 +731,7 @@ export function RouteRegistration({
 						<button
 							type="submit"
 							className="btn btn-primary"
-							disabled={submitting}
+							disabled={isFormLocked}
 						>
 							{submitting ? "保存中..." : editingId != null ? "更新" : "登録"}
 						</button>
@@ -732,8 +755,7 @@ export function RouteRegistration({
 								<NotifySettings
 									notifyBeforeMinutes={notifyBeforeMinutes}
 									setNotifyBeforeMinutes={setNotifyBeforeMinutes}
-									submitting={submitting}
-									togglingRouteId={togglingRouteId}
+									isFormLocked={isFormLocked}
 									onRequestNotificationPermission={
 										onRequestNotificationPermission
 									}
@@ -816,7 +838,7 @@ export function RouteRegistration({
 															setTogglingRouteId(null);
 														}
 													}}
-													disabled={submitting || togglingRouteId !== null}
+													disabled={isFormLocked}
 													aria-label="通知の切り替え"
 												/>
 											</td>
@@ -825,7 +847,7 @@ export function RouteRegistration({
 													type="button"
 													className="btn btn-ghost btn-xs"
 													onClick={() => handleEdit(route)}
-													disabled={submitting || togglingRouteId !== null}
+													disabled={isFormLocked}
 												>
 													編集
 												</button>
@@ -833,7 +855,7 @@ export function RouteRegistration({
 													type="button"
 													className="btn btn-ghost btn-xs text-error"
 													onClick={() => handleDelete(route.id)}
-													disabled={submitting || togglingRouteId !== null}
+													disabled={isFormLocked}
 												>
 													削除
 												</button>

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -521,12 +521,18 @@ export function RouteRegistration({
 			// permission 要求は副作用としてのみ呼び、結果で notifyEnabled を上書きしない
 			// （登録済み経路トグルと同じポリシー）。
 			const notifyEnabled = form.notifyEnabled;
-			if (notifyEnabled && onRequestNotificationPermission) {
-				await onRequestNotificationPermission();
-			}
 
+			// PR #104 CodeRabbit 指摘対応：permission プロンプトは秒〜分単位の
+			// ユーザー判断待ちになりうるため、await より前に setSubmitting(true)
+			// を呼んで isFormLocked=true にし、その間の入力レースを防ぐ。
+			// また permission 経路の reject も同じ try/catch で捕捉するため、
+			// await も try ブロック内に含める。
 			setSubmitting(true);
 			try {
+				if (notifyEnabled && onRequestNotificationPermission) {
+					await onRequestNotificationPermission();
+				}
+
 				const entry: Omit<RouteEntry, "id"> = {
 					fromStopId: form.fromStop.stop_id,
 					toStopId: form.toStop.stop_id,

--- a/src/components/RouteRegistration.tsx
+++ b/src/components/RouteRegistration.tsx
@@ -303,6 +303,7 @@ function NotifySettings({
 							commitNotifyInput();
 						}
 					}}
+					disabled={isFormLocked}
 				/>
 				<span id="notify-before-minutes-unit" className="text-base-content/70">
 					分前
@@ -321,6 +322,7 @@ function NotifySettings({
 						type="button"
 						className="btn btn-xs btn-outline"
 						onClick={onRequestNotificationPermission}
+						disabled={isFormLocked}
 					>
 						通知を許可
 					</button>

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -70,11 +70,11 @@ type StopSearchProps = {
 	 *   経由のドロップダウン再オープンを防ぐ。
 	 * - `handleSearch` / `handleSelect` / `handleKeyDown` / `onFocus` は
 	 *   早期リターンして no-op になる。
-	 * - すでに開いていた listbox は閉じる（false→true 遷移を useEffect で
-	 *   観測）。これは「props→state 同期」ではなく片方向・一回性の
-	 *   リアクションであり、Issue #99 で排除したアンチパターンとは別物。
-	 *   WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を作らない
-	 *   ことが目的。
+	 * - listbox の描画条件 `isListboxOpen` に `!disabled` を AND しているため、
+	 *   開いていた listbox は disabled=true の瞬間から描画されない
+	 *   （派生値による表現。useEffect で isOpen を書き戻す必要はない）。
+	 *   WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を
+	 *   作らないことが目的。
 	 */
 	disabled?: boolean;
 };
@@ -107,11 +107,17 @@ export function StopSearch({
 	}, [db, query, reachabilityFilter]);
 
 	// listbox の実在状態。`isOpen` は「ユーザーが明示的に閉じていない」を表し、
-	// 実際に listbox を描画するか否かは候補の有無との AND で決まる。
+	// 実際に listbox を描画するか否かは候補の有無と disabled の否との AND で決まる。
 	// aria-expanded と描画条件をこの派生値で一元化することで、候補 0 件時に
 	// aria-expanded="true" のまま listbox が無いという WAI-ARIA 違反を防ぐ
 	// （coderabbitai #96 指摘）。
-	const isListboxOpen = isOpen && results.length > 0;
+	// Issue #103 / gemini-code-assist #104: `disabled` 中は listbox を
+	// 描画しない。以前は false→true 遷移を useEffect で観測して isOpen を
+	// 倒していたが、派生値で表現すれば useEffect による「props → state
+	// の片方向反映」すら不要になる（React 公式「You Might Not Need an
+	// Effect」の徹底）。ユーザーが disabled 解除後に input にフォーカス
+	// すれば onFocus → setIsOpen(true) で自然に復帰する。
+	const isListboxOpen = !disabled && isOpen && results.length > 0;
 
 	const handleSearch = useCallback(
 		(value: string) => {
@@ -181,19 +187,6 @@ export function StopSearch({
 		},
 		[isOpen, results, activeIndex, handleSelect, disabled],
 	);
-
-	// Issue #103: disabled 化の瞬間に開いていた listbox を閉じる。
-	// WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を作らない
-	// ためのリアクションで、false→true の一回性の片方向フロー。
-	// 「props→state 同期」（Issue #99 で排除したアンチパターン）とは別物で、
-	// 内部 state（isOpen / activeIndex）と prop（disabled）の二重管理は
-	// 発生しない。
-	useEffect(() => {
-		if (disabled) {
-			setIsOpen(false);
-			setActiveIndex(-1);
-		}
-	}, [disabled]);
 
 	// ドロップダウン外クリックで閉じる
 	useEffect(() => {

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -70,11 +70,16 @@ type StopSearchProps = {
 	 *   経由のドロップダウン再オープンを防ぐ。
 	 * - `handleSearch` / `handleSelect` / `handleKeyDown` / `onFocus` は
 	 *   早期リターンして no-op になる。
-	 * - listbox の描画条件 `isListboxOpen` に `!disabled` を AND しているため、
-	 *   開いていた listbox は disabled=true の瞬間から描画されない
-	 *   （派生値による表現。useEffect で isOpen を書き戻す必要はない）。
+	 * - listbox は「派生値 + useEffect」の二段構えで閉じる：
+	 *   - 派生値 `isListboxOpen = !disabled && isOpen && results.length > 0`
+	 *     により、false→true 遷移のレンダリング段階から listbox を非表示に
+	 *     する（1 フレーム描画問題を回避）。
+	 *   - `useEffect([disabled])` で disabled=true の間に内部 `isOpen` を
+	 *     false に倒し、true→false 逆遷移時に listbox が自動再表示される
+	 *     UX バグを防ぐ（disabled 解除後の再オープンはユーザーの明示操作
+	 *     （focus/入力）を必要とする）。
 	 *   WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を
-	 *   作らないことが目的。
+	 *   作らないことと、ユーザーの意図しない listbox 復活を防ぐことが目的。
 	 */
 	disabled?: boolean;
 };
@@ -111,12 +116,13 @@ export function StopSearch({
 	// aria-expanded と描画条件をこの派生値で一元化することで、候補 0 件時に
 	// aria-expanded="true" のまま listbox が無いという WAI-ARIA 違反を防ぐ
 	// （coderabbitai #96 指摘）。
-	// Issue #103 / gemini-code-assist #104: `disabled` 中は listbox を
-	// 描画しない。以前は false→true 遷移を useEffect で観測して isOpen を
-	// 倒していたが、派生値で表現すれば useEffect による「props → state
-	// の片方向反映」すら不要になる（React 公式「You Might Not Need an
-	// Effect」の徹底）。ユーザーが disabled 解除後に input にフォーカス
-	// すれば onFocus → setIsOpen(true) で自然に復帰する。
+	// Issue #103 / gemini-code-assist #104（コメント2）：描画条件に `!disabled` を
+	// AND することで、disabled=false→true 遷移の 1 フレーム描画問題を防ぐ。
+	// これと対になる「disabled=true→false 逆遷移で内部 isOpen が残り listbox
+	// が自動再表示される問題」は下の useEffect で内部 state をリセットして
+	// 対応する（PR #104 coderabbitai 指摘）。両者は異なる遷移方向に対応する
+	// 二段構えで、相補的に「disabled 中は listbox が閉じ、解除後もユーザーの
+	// 明示操作があるまで再表示されない」契約を保つ。
 	const isListboxOpen = !disabled && isOpen && results.length > 0;
 
 	const handleSearch = useCallback(
@@ -187,6 +193,27 @@ export function StopSearch({
 		},
 		[isOpen, results, activeIndex, handleSelect, disabled],
 	);
+
+	// PR #104 coderabbitai 指摘対応：disabled=true 中に内部 `isOpen` を
+	// false にリセットする。派生値 `isListboxOpen = !disabled && ...` だけ
+	// では disabled=true→false の逆遷移時に内部 isOpen が保持され、
+	// query が残っていれば listbox が自動再表示されてしまう（submit 失敗時・
+	// toggleRoute 完了時に「触っていない listbox が勝手に復活」する UX バグ）。
+	// 本 useEffect と派生値は異なる遷移方向に対応する二段構え：
+	// - 派生値（`!disabled && ...`）：disabled=false→true 遷移のレンダリング
+	//   フレーム段階から listbox を非表示にし、gemini-code-assist #104 の
+	//   1 フレーム描画問題を防ぐ。
+	// - 本 useEffect：disabled=true の間に内部 `isOpen` を false に倒し、
+	//   disabled=false に戻ったときにユーザーの明示操作（focus/入力）なしで
+	//   listbox が再表示される UX バグを防ぐ。
+	// どちらも「props→state 同期」（双方向・常時追従）ではなく、`disabled`
+	// が true のときに限って内部 state を一方向にクリアする片方向リセット。
+	useEffect(() => {
+		if (disabled) {
+			setIsOpen(false);
+			setActiveIndex(-1);
+		}
+	}, [disabled]);
 
 	// ドロップダウン外クリックで閉じる
 	useEffect(() => {

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -60,6 +60,23 @@ type StopSearchProps = {
 	 * 親コンポーネントで構築して渡す。
 	 */
 	reachabilityFilter?: ReachabilityFilter;
+	/**
+	 * Issue #103: フォーム全体を一時的に操作禁止にしたいときに true を渡す。
+	 * 典型的には送信処理中（`submitting`）や他の副作用処理中
+	 * （`togglingRouteId !== null` など）のレースコンディション回避に使う。
+	 *
+	 * true のときの挙動：
+	 * - `input` に HTML `disabled` 属性を付与し、キー入力・フォーカス獲得
+	 *   経由のドロップダウン再オープンを防ぐ。
+	 * - `handleSearch` / `handleSelect` / `handleKeyDown` / `onFocus` は
+	 *   早期リターンして no-op になる。
+	 * - すでに開いていた listbox は閉じる（false→true 遷移を useEffect で
+	 *   観測）。これは「props→state 同期」ではなく片方向・一回性の
+	 *   リアクションであり、Issue #99 で排除したアンチパターンとは別物。
+	 *   WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を作らない
+	 *   ことが目的。
+	 */
+	disabled?: boolean;
 };
 
 /** バス停名のインクリメンタルサーチコンポーネント */
@@ -72,6 +89,7 @@ export function StopSearch({
 	selectedStop = null,
 	placeholder = "バス停名を入力",
 	reachabilityFilter,
+	disabled = false,
 }: StopSearchProps) {
 	const id = useId();
 	const [isOpen, setIsOpen] = useState(false);
@@ -97,6 +115,10 @@ export function StopSearch({
 
 	const handleSearch = useCallback(
 		(value: string) => {
+			// Issue #103: disabled 中は親 state を書き換えない。
+			// HTML disabled 属性で通常の入力経路は塞がれるが、プログラム的に
+			// value が来るケースも想定して早期リターンで二重に防ぐ。
+			if (disabled) return;
 			onQueryChange(value);
 			setActiveIndex(-1);
 			// 選択済み状態で入力値が選択 stop の名称と乖離したら、親側の
@@ -115,21 +137,25 @@ export function StopSearch({
 			// results は派生値として自動再計算されるため、ここでは開閉のみ制御する。
 			setIsOpen(true);
 		},
-		[selectedStop, onSelect, onQueryChange],
+		[selectedStop, onSelect, onQueryChange, disabled],
 	);
 
 	const handleSelect = useCallback(
 		(stop: StopSearchResult) => {
+			// Issue #103: disabled 中は候補クリックも無効化する。
+			// option 側の onClick 条件分岐と併せた二重ガード。
+			if (disabled) return;
 			onQueryChange(stop.stop_name);
 			setIsOpen(false);
 			setActiveIndex(-1);
 			onSelect(stop);
 		},
-		[onSelect, onQueryChange],
+		[onSelect, onQueryChange, disabled],
 	);
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
+			if (disabled) return;
 			if (!isOpen || results.length === 0) return;
 
 			switch (e.key) {
@@ -153,8 +179,21 @@ export function StopSearch({
 					break;
 			}
 		},
-		[isOpen, results, activeIndex, handleSelect],
+		[isOpen, results, activeIndex, handleSelect, disabled],
 	);
+
+	// Issue #103: disabled 化の瞬間に開いていた listbox を閉じる。
+	// WAI-ARIA 観点で「操作不能なのに listbox が見えている」状態を作らない
+	// ためのリアクションで、false→true の一回性の片方向フロー。
+	// 「props→state 同期」（Issue #99 で排除したアンチパターン）とは別物で、
+	// 内部 state（isOpen / activeIndex）と prop（disabled）の二重管理は
+	// 発生しない。
+	useEffect(() => {
+		if (disabled) {
+			setIsOpen(false);
+			setActiveIndex(-1);
+		}
+	}, [disabled]);
 
 	// ドロップダウン外クリックで閉じる
 	useEffect(() => {
@@ -186,8 +225,10 @@ export function StopSearch({
 				onChange={(e) => handleSearch(e.target.value)}
 				onKeyDown={handleKeyDown}
 				onFocus={() => {
+					if (disabled) return;
 					if (results.length > 0) setIsOpen(true);
 				}}
+				disabled={disabled}
 				role="combobox"
 				aria-autocomplete="list"
 				aria-expanded={isListboxOpen}
@@ -239,7 +280,15 @@ export function StopSearch({
 							role="option"
 							aria-selected={index === activeIndex}
 							tabIndex={-1}
-							onClick={() => handleSelect(stop)}
+							onClick={() => {
+								// Issue #103: disabled 中はクリックでも反応しない。
+								// handleSelect の早期リターンと合わせた二重ガード。
+								// 通常は disabled 化で listbox 自体が閉じるためここに
+								// 到達しないが、CSS の pointer-events を使う代替は
+								// DaisyUI 側のスタイルと衝突するためこちらを採る。
+								if (disabled) return;
+								handleSelect(stop);
+							}}
 							onMouseEnter={() => setActiveIndex(index)}
 						>
 							<span className="inline-flex flex-wrap items-center gap-1">

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -2000,6 +2000,76 @@ describe("RouteRegistration コンポーネント", () => {
 			resolveUpdate();
 		});
 
+		// gemini-code-assist PR #104 指摘:
+		// NotifySettings 内部の通知タイミング input と「通知を許可」ボタンも
+		// isFormLocked（= submitting || togglingRouteId !== null）で一律
+		// 無効化する。親の async 処理中に子コンポーネントの関連コントロールが
+		// 独立して操作可能な状態を残すと、Issue #103 の「フォーム全体を派生値で
+		// 束ねる」趣旨と矛盾する。
+		it("submitting=true 中は通知タイミング input が disabled になる", async () => {
+			let resolveDelete: () => void = () => {};
+			const onDelete = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveDelete = r;
+					}),
+			);
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={onDelete}
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+				/>,
+			);
+			const input = screen.getByRole("spinbutton", { name: "通知タイミング" });
+			expect(input).not.toBeDisabled();
+
+			// 削除をクリックして submitting=true を作る
+			await userEvent.click(screen.getByRole("button", { name: "削除" }));
+			expect(input).toBeDisabled();
+
+			resolveDelete();
+		});
+
+		it("submitting=true 中は「通知を許可」ボタンが disabled になる", async () => {
+			let resolveDelete: () => void = () => {};
+			const onDelete = vi.fn(
+				() =>
+					new Promise<void>((r) => {
+						resolveDelete = r;
+					}),
+			);
+			// notifyPermission="default" + onRequestNotificationPermission を渡すと
+			// 「通知を許可」ボタンが描画される。
+			const onRequestNotificationPermission = vi
+				.fn()
+				.mockResolvedValue("default" as NotificationPermission);
+			render(
+				<NotifyHarness
+					db={db}
+					routes={notifyEnabledRoutes}
+					onAdd={vi.fn().mockResolvedValue(1)}
+					onUpdate={vi.fn().mockResolvedValue(undefined)}
+					onDelete={onDelete}
+					onRequestNotificationPermission={onRequestNotificationPermission}
+					notifyPermission="default"
+					hasNotifyEnabledRoutes={true}
+					initialMinutes={5}
+				/>,
+			);
+			const allowButton = screen.getByRole("button", { name: "通知を許可" });
+			expect(allowButton).not.toBeDisabled();
+
+			await userEvent.click(screen.getByRole("button", { name: "削除" }));
+			expect(allowButton).toBeDisabled();
+
+			resolveDelete();
+		});
+
 		it("commit が失敗したとき入力欄の表示が元の値に戻る", async () => {
 			// 設定確定に失敗したのに入力欄だけ新しい値のまま残ると、
 			// 保存されている値と画面表示が乖離してユーザーの誤解を招く。

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -3,6 +3,7 @@ import {
 	fireEvent,
 	render as rtlRender,
 	screen,
+	within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactElement, useState } from "react";
@@ -1120,9 +1121,12 @@ describe("RouteRegistration コンポーネント", () => {
 		resolveUpdate();
 	});
 
-	it("トグル処理中でも経路登録ボタンの表示（テキスト・disabled）は変わらない", async () => {
-		// 通知の ON/OFF をするたびに登録ボタンが「保存中...」になったり disabled になったり
-		// 揺れる問題を回避する。トグル操作はフォーム送信と独立した状態で管理すべき。
+	it("トグル処理中は登録ボタンが disabled になるがテキストは「登録」のまま変わらない", async () => {
+		// 通知の ON/OFF をするたびに登録ボタンのテキストが「保存中...」に
+		// 揺れる問題は引き続き回避する（submitting と togglingRouteId を
+		// 分離管理する元々の目的）。ただし Issue #103 の対称化により、
+		// disabled 状態はフォーム側と同じく isFormLocked=true の間
+		// 立つようになった（キャンセルボタンと同契約）。
 		const routes: RegisteredRouteEntry[] = [
 			{
 				id: 1,
@@ -1155,9 +1159,10 @@ describe("RouteRegistration コンポーネント", () => {
 			screen.getByRole("checkbox", { name: "通知の切り替え" }),
 		);
 
-		// トグル処理が保留中でも登録ボタンは「登録」のままで enabled
+		// トグル処理中でもテキストは「登録」のまま（submitting=false のため）。
+		// ただし Issue #103 によって disabled は立つ。
 		expect(submitButton).toHaveTextContent("登録");
-		expect(submitButton).not.toBeDisabled();
+		expect(submitButton).toBeDisabled();
 
 		resolveUpdate();
 	});
@@ -2336,5 +2341,134 @@ describe("RouteRegistration（到達可能性フィルタ）", () => {
 			/乗り換えなしで到達できる便が見つかりませんでした/,
 		);
 		expect(onUpdate).not.toHaveBeenCalled();
+	});
+});
+
+describe("RouteRegistration（送信中の入力系無効化 / Issue #103）", () => {
+	// Issue #103: submit 処理が pending の間、ユーザーの新しい入力が await
+	// 解決後の resetForm で吹き飛ぶレースを避けるため、入力系 3 種
+	// （乗車/降車 StopSearch × 2、徒歩時間 input、通知 checkbox）と
+	// フォーム側ボタン、一覧の通知トグルをすべて disabled にする。
+	// 派生値 `isFormLocked = submitting || togglingRouteId !== null` で
+	// 束ねることで、キャンセルボタンと登録/更新ボタンの disabled 条件の
+	// 非対称（submitting のみ vs submitting || togglingRouteId !== null）も
+	// 同じ契約に揃える。
+	it("onAdd 解決前は入力系 3 種とフォーム側ボタンが disabled になる", async () => {
+		const onAdd = vi.fn().mockReturnValue(new Promise<number>(() => {}));
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={[]}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// 乗車/降車を選択して submit 条件を満たす
+		const comboboxes = screen.getAllByRole("combobox");
+		await userEvent.type(comboboxes[0], "旭川駅");
+		await userEvent.click(screen.getByText("旭川駅前"));
+		await userEvent.type(comboboxes[1], "市役所");
+		await userEvent.click(screen.getByText("市役所前"));
+
+		// 登録クリック → onAdd が pending のまま submitting=true が継続
+		await userEvent.click(screen.getByRole("button", { name: "登録" }));
+
+		// 3 入力系
+		const [fromCombo, toCombo] = screen.getAllByRole("combobox");
+		expect(fromCombo).toBeDisabled();
+		expect(toCombo).toBeDisabled();
+		expect(screen.getByLabelText("徒歩所要時間（分）")).toBeDisabled();
+		expect(screen.getByRole("checkbox", { name: "通知" })).toBeDisabled();
+
+		// フォーム側ボタン（登録中なので「保存中...」ラベル）
+		expect(screen.getByRole("button", { name: "保存中..." })).toBeDisabled();
+	});
+
+	it("通知トグル処理中（togglingRouteId !== null）は登録ボタンも disabled になる", async () => {
+		// キャンセルボタンは既に submitting || togglingRouteId !== null で
+		// disabled 化される契約になっているが、登録/更新ボタンは submitting
+		// のみで togglingRouteId を参照していなかった既存の非対称を揃える。
+		let resolveUpdate: () => void = () => {};
+		const onAdd = vi.fn().mockResolvedValue(1);
+		const onUpdate = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolveUpdate = r;
+				}),
+		);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		const routes: RegisteredRouteEntry[] = [
+			{ id: 1, fromStopId: "test:S001", toStopId: "test:S002", walkMinutes: 5 },
+		];
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// トグルクリックで togglingRouteId !== null
+		await userEvent.click(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		);
+
+		// 登録ボタンが disabled になることを検証（対称化）
+		expect(screen.getByRole("button", { name: "登録" })).toBeDisabled();
+
+		resolveUpdate();
+	});
+
+	it("onAdd 解決前は一覧の通知トグル・編集・削除ボタンも disabled になる", async () => {
+		// 既存の 3 箇所（一覧通知トグル・編集・削除）は submitting のみで
+		// disabled 化されていたが、派生値 isFormLocked で束ねても挙動が
+		// 変わらないことを回帰として保証する。
+		const onAdd = vi.fn().mockReturnValue(new Promise<number>(() => {}));
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+
+		const routes: RegisteredRouteEntry[] = [
+			{ id: 1, fromStopId: "test:S001", toStopId: "test:S002", walkMinutes: 5 },
+		];
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={routes}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+			/>,
+		);
+
+		const comboboxes = screen.getAllByRole("combobox");
+		await userEvent.type(comboboxes[0], "旭川駅");
+		// 既登録ルートの表にも同名セルがあるため listbox 内で絞る
+		await userEvent.click(
+			within(screen.getByRole("listbox")).getByText("旭川駅前"),
+		);
+		await userEvent.type(comboboxes[1], "市役所");
+		await userEvent.click(
+			within(screen.getByRole("listbox")).getByText("市役所前"),
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "登録" }));
+
+		// submit 後、登録ボタンは「保存中...」ラベルに切り替わる
+		expect(screen.getByRole("button", { name: "保存中..." })).toBeDisabled();
+		expect(
+			screen.getByRole("checkbox", { name: "通知の切り替え" }),
+		).toBeDisabled();
+		expect(screen.getByRole("button", { name: "編集" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "削除" })).toBeDisabled();
 	});
 });

--- a/test/RouteRegistration.test.tsx
+++ b/test/RouteRegistration.test.tsx
@@ -2498,6 +2498,53 @@ describe("RouteRegistration（送信中の入力系無効化 / Issue #103）", (
 		resolveUpdate();
 	});
 
+	// PR #104 CodeRabbit 指摘対応：permission プロンプトは秒〜分単位の
+	// ユーザー判断待ちになりうるため、await 中も isFormLocked=true となって
+	// いないと入力レースが発生する。setSubmitting(true) を permission 要求の
+	// 前に移動した挙動を検証する（permission pending 中に入力系が disabled）。
+	it("通知 ON 送信で permission プロンプト pending 中も入力系 3 種が disabled になる", async () => {
+		const onAdd = vi.fn().mockResolvedValue(1);
+		const onUpdate = vi.fn().mockResolvedValue(undefined);
+		const onDelete = vi.fn().mockResolvedValue(undefined);
+		// permission プロンプトを pending のまま保持する（resolve しない）
+		const onRequestPermission = vi
+			.fn<() => Promise<NotificationPermission>>()
+			.mockReturnValue(new Promise<NotificationPermission>(() => {}));
+
+		render(
+			<RouteRegistration
+				db={db}
+				routes={[]}
+				onAdd={onAdd}
+				onUpdate={onUpdate}
+				onDelete={onDelete}
+				notifyPermission="default"
+				onRequestNotificationPermission={onRequestPermission}
+			/>,
+		);
+
+		const comboboxes = screen.getAllByRole("combobox");
+		await userEvent.type(comboboxes[0], "旭川駅");
+		await userEvent.click(screen.getByText("旭川駅前"));
+		await userEvent.type(comboboxes[1], "市役所");
+		await userEvent.click(screen.getByText("市役所前"));
+
+		// 通知 ON にしてから登録（= permission プロンプトを経由する経路）
+		await userEvent.click(screen.getByRole("checkbox", { name: "通知" }));
+		await userEvent.click(screen.getByRole("button", { name: "登録" }));
+
+		// permission プロンプトを呼んだが Promise は resolve していない
+		expect(onRequestPermission).toHaveBeenCalled();
+		expect(onAdd).not.toHaveBeenCalled();
+
+		// この時点で isFormLocked=true となって入力系 3 種が disabled
+		const [fromCombo, toCombo] = screen.getAllByRole("combobox");
+		expect(fromCombo).toBeDisabled();
+		expect(toCombo).toBeDisabled();
+		expect(screen.getByLabelText("徒歩所要時間（分）")).toBeDisabled();
+		expect(screen.getByRole("checkbox", { name: "通知" })).toBeDisabled();
+	});
+
 	it("onAdd 解決前は一覧の通知トグル・編集・削除ボタンも disabled になる", async () => {
 		// 既存の 3 箇所（一覧通知トグル・編集・削除）は submitting のみで
 		// disabled 化されていたが、派生値 isFormLocked で束ねても挙動が

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -424,6 +424,73 @@ describe("StopSearch コンポーネント", () => {
 		fireEvent.mouseDown(screen.getByText("外側ボタン"));
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 	});
+
+	// Issue #103: 送信中などフォーム全体が操作禁止のとき、StopSearch も
+	// 無効化できるようにする。disabled prop を介して input の HTML disabled
+	// 属性が立ち、ハンドラが no-op になり、既に開いていたドロップダウンが
+	// 閉じることを保証する。WAI-ARIA 観点で「操作不能なのにリストが表示
+	// されている」状態を作らないようにする。
+	it("disabled={true} では input に disabled 属性が設定される", () => {
+		const onSelect = vi.fn();
+		render(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={true}
+			/>,
+		);
+		const input = screen.getByRole("combobox");
+		expect(input).toBeDisabled();
+	});
+
+	it("disabled={true} ではキー入力で onQueryChange が呼ばれない", async () => {
+		const onSelect = vi.fn();
+		const onQueryChange = vi.fn();
+		render(
+			<StopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				query=""
+				onQueryChange={onQueryChange}
+				disabled={true}
+			/>,
+		);
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "旭川");
+		expect(onQueryChange).not.toHaveBeenCalled();
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it("disabled={false}→true 遷移で開いているドロップダウンが閉じる", async () => {
+		// disabled 化と同時に listbox を閉じる（設計判断）。
+		// false→true の一回性リアクションであり、Issue #99 で排除した
+		// props→state「同期」とは別物。
+		const onSelect = vi.fn();
+		const { rerender } = render(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={false}
+			/>,
+		);
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "旭川");
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		rerender(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={true}
+			/>,
+		);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+		expect(input).toHaveAttribute("aria-expanded", "false");
+	});
 });
 
 describe("StopSearch（到達可能性フィルタ）", () => {

--- a/test/StopSearch.test.tsx
+++ b/test/StopSearch.test.tsx
@@ -491,6 +491,53 @@ describe("StopSearch コンポーネント", () => {
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 		expect(input).toHaveAttribute("aria-expanded", "false");
 	});
+
+	// PR #104 CodeRabbit 指摘対応：派生値 isListboxOpen だけだと
+	// disabled=true→false の逆遷移時に内部 isOpen が保持されたまま、
+	// query が残っていれば listbox が勝手に再表示されてしまう。
+	// submit 失敗時や toggleRoute 完了時に「触っていない listbox が復活」
+	// する UX バグになるため、disabled=true 中に内部 isOpen を確実に
+	// リセットし、再表示にはユーザーの明示的な操作（focus など）を必要と
+	// する契約にする。
+	it("disabled={true}→false 逆遷移で listbox が自動再表示されない", async () => {
+		const onSelect = vi.fn();
+		const { rerender } = render(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={false}
+			/>,
+		);
+		const input = screen.getByRole("combobox");
+		await userEvent.type(input, "旭川");
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		// disabled を true に遷移（submit 中を模擬）
+		rerender(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={true}
+			/>,
+		);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+		// disabled を false に戻す（submit 失敗や toggleRoute 完了を模擬）
+		// query は残っているので results は非空のまま、内部 isOpen が
+		// 保持されていると listbox が自動再表示されてしまう。
+		rerender(
+			<ControlledStopSearch
+				db={db}
+				label="乗車バス停"
+				onSelect={onSelect}
+				disabled={false}
+			/>,
+		);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+		expect(input).toHaveAttribute("aria-expanded", "false");
+	});
 });
 
 describe("StopSearch（到達可能性フィルタ）", () => {


### PR DESCRIPTION
## Context

PR #102（Issue #99）の gemini-code-assist レビューで「submit 中は `StopSearch` を `disabled` にせよ」と指摘されたが、`StopSearch` だけでは一貫性を欠くため別 Issue として #103 を起票して対応する。

現状、`RouteRegistration` では送信処理中（`submitting === true`）でも入力系 3 種（乗車/降車 `StopSearch` × 2・徒歩時間 `input`・通知 `checkbox`）が操作可能で、`await` 解決後に `resetForm` が走るとユーザーの新しい操作が吹き飛ぶレースがあった。またキャンセル (`submitting || togglingRouteId !== null`) と登録/更新ボタン (`submitting` のみ) の既存非対称も同 PR で揃える（ユーザー承認済み）。

Closes #103

## Changes

### `src/components/StopSearch.tsx`

- `disabled?: boolean` prop を追加。
- `input` の HTML `disabled` 属性、`handleSearch` / `handleSelect` / `handleKeyDown` / `onFocus` の早期リターン、候補 `<div role="option">` の `onClick` の二重ガードを追加。
- disabled=true への遷移で listbox を閉じる `useEffect` を追加（WAI-ARIA：「操作不能なのに listbox が見えている」状態を作らない）。この `useEffect` は片方向・一回性のリアクションであり、Issue #99 で排除した props→state 同期アンチパターンとは別物である旨を JSDoc で明記。

### `src/components/RouteRegistration.tsx`

- 派生値 `isFormLocked = submitting || togglingRouteId !== null` を本体に定義。
- 入力系 3 種（StopSearch × 2・徒歩時間・通知 checkbox）・キャンセル・登録/更新・一覧トグル/編集/削除・`NotifySettings`（設定ボタン・Enter 経路ガード）をすべて `isFormLocked` で束ねる。
- 登録/更新ボタンの既存非対称（`submitting` 単独判定）を対称化。
- `NotifySettings` は個別 `submitting` / `togglingRouteId` props を廃止し `isFormLocked` に統合。

### テスト

- `test/StopSearch.test.tsx`：+3 件（disabled 属性・ハンドラ無効化・listbox 閉）
- `test/RouteRegistration.test.tsx`：+3 件（submit pending 中の全 disabled / toggling 中の登録ボタン disabled / 一覧の既存 disabled 回帰）。
- 既存「トグル中も登録ボタンの表示は変わらない」テストを、ラベルは変わらず disabled は立つ新仕様に追従。

### ドキュメント

- `docs/REVIEW_LESSONS.md` にカテゴリ #19「フォーム全体の無効化ポリシーを派生値で束ねる」を追加。チェックリスト・参照 PR 表も更新。

## Test plan

- [x] `npm test`：475/475 pass（追加 6 件・既存更新 1 件を含む）
- [x] `npm run build`：exit 0
- [x] `npm run check`：変更ファイルに新規 lint エラー 0 件（pre-existing な format 違反はスコープ外）
- [ ] 手動検証（`npm run dev`）：
  - 経路登録フォームに入力 → 登録ボタン押下直後、保存中の間に徒歩時間・通知 checkbox・StopSearch すべて操作不可
  - 経路一覧の通知トグルをクリック → トグル処理中に登録/更新ボタンも disabled になる（対称化の副次効果）

## Scope

対象外：
- 送信エラー時の disabled 継続ロジック（現状の finally 解除を維持）
- `ACCESSIBILITY.md` の新規整備（本 Issue 単体ではスコープ外）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * フォーム送信中やルート切り替え中の無効化動作を統一し、フォーム全体で一貫した disabled 状態を実装しました。

* **Refactor**
  * フォーム無効化ロジックを一つの派生値に統合し、全入力フィールド、ボタン、子コンポーネントに一貫して適用するよう改善しました。

* **Tests**
  * フォーム locked 状態および disabled 動作の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->