### PR TITLE
fix(ci): grant actions:write to allow Trigger deploy step

### DIFF
--- a/.github/workflows/update-gtfs.yml
+++ b/.github/workflows/update-gtfs.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   update-gtfs:


### PR DESCRIPTION
セルフレビュー実施済み．

## Summary

- `Update GTFS Data` ワークフローのスケジュール実行 ([#11](https://github.com/tomio2480/asahikawa-bus-departure/actions/runs/24978576208) 2026-04-27, [#10](https://github.com/tomio2480/asahikawa-bus-departure/actions/runs/24650079943) 2026-04-20) が，最終ステップ `Trigger deploy` で HTTP 403 を返して失敗していた．
- `gh workflow run deploy.yml` は Actions API の `workflow_dispatch` を呼ぶため，`GITHUB_TOKEN` に `actions: write` 権限が必要だが，`.github/workflows/update-gtfs.yml` の `permissions:` には `contents: write` しか付与されていなかった．
- `permissions:` に `actions: write` を 1 行追加して最小権限のまま修復する．

## Background

このステップは [6ef73b7](https://github.com/tomio2480/asahikawa-bus-departure/commit/6ef73b7) で「`GITHUB_TOKEN` 由来の push は他ワークフローを発火しない」問題への対処として追加された．直後の手動実行 (`workflow_dispatch`) は差分なしで `Trigger deploy` がスキップされたため成功扱いとなり，初の差分検出を伴うスケジュール実行 (#10) で初めて失覚した．

データ自動コミット自体は成功している ([16198d5 chore: update GTFS data 2026-04-27](https://github.com/tomio2480/asahikawa-bus-departure/commit/16198d5)) が，後続の Pages デプロイが自動で走らない症状になっている．

## ドキュメント整合性

- `README.md` 等のユーザー向け文書に影響する変更なし．
- 権限追加のみで挙動変更はないため `docs/` 配下の更新も不要．

## Test plan

- [ ] 次回スケジュール実行（毎週月曜 03:00 UTC，次回 2026-05-04）で `Trigger deploy` ステップが 200 を返すこと
- [ ] あるいは `gtfs-prev` キャッシュを GitHub UI から削除した状態で手動 `workflow_dispatch` を実行し，`changed=true` 経路で `Trigger deploy` が成功すること（任意・余分な Pages デプロイが 1 回発生する点はトレードオフ）
- [ ] `Update OSM Data` ワークフローには本件の影響がない（push もデプロイトリガーもしないため確認のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフロー設定を更新しました。

このリリースはユーザー向けの機能変更を含みません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->